### PR TITLE
feat: add organization banner to profile

### DIFF
--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 1280 320" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;">
+    <rect x="0" y="0" width="1280" height="320" style="fill:rgb(28,27,26);"/>
+    <g opacity="0.25">
+        <path d="M100,50L180,90" style="fill:none;fill-rule:nonzero;stroke:rgb(58,169,159);stroke-width:0.8px;"/>
+        <path d="M180,90L140,170" style="fill:none;fill-rule:nonzero;stroke:rgb(58,169,159);stroke-width:0.8px;"/>
+        <path d="M140,170L70,240" style="fill:none;fill-rule:nonzero;stroke:rgb(58,169,159);stroke-width:0.8px;"/>
+        <path d="M100,50L260,120" style="fill:none;fill-rule:nonzero;stroke:rgb(58,169,159);stroke-width:0.8px;"/>
+        <path d="M260,120L340,70" style="fill:none;fill-rule:nonzero;stroke:rgb(58,169,159);stroke-width:0.8px;"/>
+        <path d="M180,90L260,120" style="fill:none;fill-rule:nonzero;stroke:rgb(58,169,159);stroke-width:0.8px;"/>
+        <path d="M340,70L420,160" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:0.8px;"/>
+        <path d="M260,120L360,220" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:0.8px;"/>
+        <path d="M140,170L220,260" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:0.8px;"/>
+        <path d="M420,160L520,100" style="fill:none;fill-rule:nonzero;stroke:rgb(58,169,159);stroke-width:0.8px;"/>
+        <path d="M520,100L600,180" style="fill:none;fill-rule:nonzero;stroke:rgb(58,169,159);stroke-width:0.8px;"/>
+        <path d="M600,180L700,140" style="fill:none;fill-rule:nonzero;stroke:rgb(58,169,159);stroke-width:0.8px;"/>
+        <path d="M700,140L780,220" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:0.8px;"/>
+        <path d="M520,100L640,60" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:0.8px;"/>
+        <path d="M880,70L960,130" style="fill:none;fill-rule:nonzero;stroke:rgb(58,169,159);stroke-width:0.8px;"/>
+        <path d="M960,130L1040,90" style="fill:none;fill-rule:nonzero;stroke:rgb(58,169,159);stroke-width:0.8px;"/>
+        <path d="M1040,90L1130,170" style="fill:none;fill-rule:nonzero;stroke:rgb(58,169,159);stroke-width:0.8px;"/>
+        <path d="M1130,170L1200,230" style="fill:none;fill-rule:nonzero;stroke:rgb(58,169,159);stroke-width:0.8px;"/>
+        <path d="M960,130L1130,170" style="fill:none;fill-rule:nonzero;stroke:rgb(58,169,159);stroke-width:0.8px;"/>
+        <path d="M880,70L1040,90" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:0.8px;"/>
+        <path d="M1040,230L1130,170" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:0.8px;"/>
+        <path d="M780,220L880,70" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:0.8px;"/>
+    </g>
+    <g opacity="0.4">
+        <g id="miniAt" transform="matrix(1,0,0,1,100,50)">
+            <g transform="matrix(0.15,0,0,0.15,0,0)">
+                <circle cx="0" cy="0" r="30" style="fill:none;stroke:rgb(139,126,200);stroke-width:8px;"/>
+                <circle cx="0" cy="0" r="12" style="fill:rgb(139,126,200);"/>
+                <path d="M25,-8C31.667,-8 35,-2.667 35,8L35,22" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:8px;"/>
+            </g>
+        </g>
+        <g id="miniCircle" transform="matrix(1,0,0,1,180,90)">
+            <circle cx="0" cy="0" r="7" style="fill:none;stroke:rgb(139,126,200);stroke-width:2px;"/>
+        </g>
+        <g id="miniAt1" serif:id="miniAt" transform="matrix(1,0,0,1,140,170)">
+            <g transform="matrix(0.15,0,0,0.15,0,0)">
+                <circle cx="0" cy="0" r="30" style="fill:none;stroke:rgb(139,126,200);stroke-width:8px;"/>
+                <circle cx="0" cy="0" r="12" style="fill:rgb(139,126,200);"/>
+                <path d="M25,-8C31.667,-8 35,-2.667 35,8L35,22" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:8px;"/>
+            </g>
+        </g>
+        <g id="miniCircle1" serif:id="miniCircle" transform="matrix(1,0,0,1,340,70)">
+            <circle cx="0" cy="0" r="7" style="fill:none;stroke:rgb(139,126,200);stroke-width:2px;"/>
+        </g>
+        <g id="miniAt2" serif:id="miniAt" transform="matrix(1,0,0,1,520,100)">
+            <g transform="matrix(0.15,0,0,0.15,0,0)">
+                <circle cx="0" cy="0" r="30" style="fill:none;stroke:rgb(139,126,200);stroke-width:8px;"/>
+                <circle cx="0" cy="0" r="12" style="fill:rgb(139,126,200);"/>
+                <path d="M25,-8C31.667,-8 35,-2.667 35,8L35,22" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:8px;"/>
+            </g>
+        </g>
+        <g id="miniCircle2" serif:id="miniCircle" transform="matrix(1,0,0,1,700,140)">
+            <circle cx="0" cy="0" r="7" style="fill:none;stroke:rgb(139,126,200);stroke-width:2px;"/>
+        </g>
+        <g id="miniAt3" serif:id="miniAt" transform="matrix(1,0,0,1,880,70)">
+            <g transform="matrix(0.15,0,0,0.15,0,0)">
+                <circle cx="0" cy="0" r="30" style="fill:none;stroke:rgb(139,126,200);stroke-width:8px;"/>
+                <circle cx="0" cy="0" r="12" style="fill:rgb(139,126,200);"/>
+                <path d="M25,-8C31.667,-8 35,-2.667 35,8L35,22" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:8px;"/>
+            </g>
+        </g>
+        <g id="miniCircle3" serif:id="miniCircle" transform="matrix(1,0,0,1,1040,90)">
+            <circle cx="0" cy="0" r="7" style="fill:none;stroke:rgb(139,126,200);stroke-width:2px;"/>
+        </g>
+        <g id="miniAt4" serif:id="miniAt" transform="matrix(1,0,0,1,1200,230)">
+            <g transform="matrix(0.15,0,0,0.15,0,0)">
+                <circle cx="0" cy="0" r="30" style="fill:none;stroke:rgb(139,126,200);stroke-width:8px;"/>
+                <circle cx="0" cy="0" r="12" style="fill:rgb(139,126,200);"/>
+                <path d="M25,-8C31.667,-8 35,-2.667 35,8L35,22" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:8px;"/>
+            </g>
+        </g>
+        <g id="miniPlus" transform="matrix(1,0,0,1,70,240)">
+            <path d="M-7,0L7,0" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:2.5px;stroke-linecap:round;"/>
+            <path d="M0,-7L0,7" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:2.5px;stroke-linecap:round;"/>
+        </g>
+        <g id="miniCircle4" serif:id="miniCircle" transform="matrix(1,0,0,1,260,120)">
+            <circle cx="0" cy="0" r="7" style="fill:none;stroke:rgb(139,126,200);stroke-width:2px;"/>
+        </g>
+        <g id="miniPlus1" serif:id="miniPlus" transform="matrix(1,0,0,1,220,260)">
+            <path d="M-7,0L7,0" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:2.5px;stroke-linecap:round;"/>
+            <path d="M0,-7L0,7" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:2.5px;stroke-linecap:round;"/>
+        </g>
+        <g id="miniCircle5" serif:id="miniCircle" transform="matrix(1,0,0,1,360,220)">
+            <circle cx="0" cy="0" r="7" style="fill:none;stroke:rgb(139,126,200);stroke-width:2px;"/>
+        </g>
+        <g id="miniPlus2" serif:id="miniPlus" transform="matrix(1,0,0,1,420,160)">
+            <path d="M-7,0L7,0" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:2.5px;stroke-linecap:round;"/>
+            <path d="M0,-7L0,7" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:2.5px;stroke-linecap:round;"/>
+        </g>
+        <g id="miniCircle6" serif:id="miniCircle" transform="matrix(1,0,0,1,600,180)">
+            <circle cx="0" cy="0" r="7" style="fill:none;stroke:rgb(139,126,200);stroke-width:2px;"/>
+        </g>
+        <g id="miniPlus3" serif:id="miniPlus" transform="matrix(1,0,0,1,640,60)">
+            <path d="M-7,0L7,0" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:2.5px;stroke-linecap:round;"/>
+            <path d="M0,-7L0,7" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:2.5px;stroke-linecap:round;"/>
+        </g>
+        <g id="miniCircle7" serif:id="miniCircle" transform="matrix(1,0,0,1,780,220)">
+            <circle cx="0" cy="0" r="7" style="fill:none;stroke:rgb(139,126,200);stroke-width:2px;"/>
+        </g>
+        <g id="miniPlus4" serif:id="miniPlus" transform="matrix(1,0,0,1,960,130)">
+            <path d="M-7,0L7,0" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:2.5px;stroke-linecap:round;"/>
+            <path d="M0,-7L0,7" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:2.5px;stroke-linecap:round;"/>
+        </g>
+        <g id="miniCircle8" serif:id="miniCircle" transform="matrix(1,0,0,1,1130,170)">
+            <circle cx="0" cy="0" r="7" style="fill:none;stroke:rgb(139,126,200);stroke-width:2px;"/>
+        </g>
+        <g id="miniPlus5" serif:id="miniPlus" transform="matrix(1,0,0,1,1040,230)">
+            <path d="M-7,0L7,0" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:2.5px;stroke-linecap:round;"/>
+            <path d="M0,-7L0,7" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:2.5px;stroke-linecap:round;"/>
+        </g>
+    </g>
+    <g>
+        <g transform="matrix(1,0,0,1,80,145)">
+            <text x="0px" y="0px" style="font-family:'Helvetica-Bold', 'Helvetica';font-weight:700;font-size:76px;fill:rgb(255,252,240);">A<tspan x="47.761px 92.665px 137.569px 182.473px 210.529px " y="0px 0px 0px 0px 0px ">Tgora</tspan></text>
+        </g>
+        <g transform="matrix(1,0,0,1,80,195)">
+            <text x="0px" y="0px" style="font-family:'Helvetica';font-size:28px;fill:rgb(255,252,240);">Community forums built on open protocol</text>
+        </g>
+        <rect x="80" y="210" width="140" height="2" style="fill:rgb(58,169,159);fill-opacity:0.6;"/>
+    </g>
+    <g transform="matrix(0.4935,0,0,0.4935,988.698258,25.583008)">
+        <path d="M128,71.5C159.183,71.5 184.5,96.817 184.5,128C184.5,159.183 159.183,184.5 128,184.5C96.817,184.5 71.5,159.183 71.5,128C71.5,96.817 96.817,71.5 128,71.5ZM128,104.5C115.03,104.5 104.5,115.03 104.5,128C104.5,140.97 115.03,151.5 128,151.5C140.97,151.5 151.5,140.97 151.5,128C151.5,115.03 140.97,104.5 128,104.5Z" style="fill:rgb(58,169,159);"/>
+    </g>
+    <g transform="matrix(0.4935,0,0,0.4935,988.698258,25.583008)">
+        <path d="M174.866,194.259C182.45,189.218 192.7,191.282 197.741,198.866C202.782,206.45 200.718,216.7 193.134,221.741C175.432,233.507 150.846,240.5 128,240.5C66.284,240.5 15.5,189.716 15.5,128C15.5,66.284 66.284,15.5 128,15.5C189.716,15.5 240.5,66.284 240.5,128C240.5,160.538 225.46,184.5 196,184.5C166.54,184.5 151.5,160.538 151.5,128L151.5,88C151.5,78.893 158.893,71.5 168,71.5C177.107,71.5 184.5,78.893 184.5,88L184.5,128C184.5,134.408 185.237,140.363 187.279,145.164C188.851,148.858 191.536,151.5 196,151.5C200.464,151.5 203.149,148.858 204.721,145.164C206.763,140.363 207.5,134.408 207.5,128C207.5,84.388 171.612,48.5 128,48.5C84.388,48.5 48.5,84.388 48.5,128C48.5,171.612 84.388,207.5 128,207.5C144.415,207.5 162.148,202.713 174.866,194.259Z" style="fill:rgb(58,169,159);"/>
+    </g>
+    <g transform="matrix(1.480499,0,0,1.480499,933.056162,-29.688963)">
+        <circle cx="176" cy="80" r="32" style="fill:none;stroke:rgb(255,252,240);stroke-width:12px;stroke-linecap:round;stroke-linejoin:round;"/>
+    </g>
+    <g transform="matrix(1.480499,0,0,1.480499,933.056162,-29.318838)">
+        <circle cx="80" cy="176" r="32" style="fill:none;stroke:rgb(255,252,240);stroke-width:12px;stroke-linecap:round;stroke-linejoin:round;"/>
+    </g>
+    <g transform="matrix(1.480499,0,0,1.480499,933.056162,-29.318838)">
+        <path d="M176,144L176,208" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:11px;stroke-linecap:round;stroke-linejoin:round;"/>
+    </g>
+    <g transform="matrix(1.480499,0,0,1.480499,933.056162,-29.318838)">
+        <path d="M208,176L144,176" style="fill:none;fill-rule:nonzero;stroke:rgb(139,126,200);stroke-width:11px;stroke-linecap:round;stroke-linejoin:round;"/>
+    </g>
+</svg>

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,4 @@
-# ATgora
-
-**Community forums built on open protocol**
+![ATgora Banner](https://raw.githubusercontent.com/atgora-forum/.github/main/assets/banner.svg)
 
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL%203.0-blue.svg)](https://opensource.org/licenses/AGPL-3.0)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
## Description

Adds professional banner to organization profile page.

## What's Included

- SVG banner (1280x320px, vector, fully scalable)
- ATgora logo (right side, large)
- Text + tagline (left side)
- Network pattern background using logo elements
- Pure Flexoki colors (no gradients)

## Preview

The banner will appear at the top of https://github.com/atgora-forum

## Type of Change

- [x] Documentation update (visual)

## Checklist

- [x] Uses exact Flexoki brand colors
- [x] Logo properly positioned and scaled
- [x] SVG optimized for GitHub rendering
- [x] Self-review completed