### PR TITLE
chore: add org-wide issue templates and update CoC reference

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,96 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill out the sections below so we can reproduce and fix it.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: Describe the bug...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this?
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: repo
+    attributes:
+      label: Which component?
+      options:
+        - barazo-api (backend)
+        - barazo-web (frontend)
+        - barazo-lexicons (schemas)
+        - barazo-deploy (Docker/hosting)
+        - barazo-website (docs site)
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: hosting
+    attributes:
+      label: Hosting type
+      description: Are you self-hosting or using managed hosting?
+      options:
+        - Self-hosted
+        - Managed hosting
+        - Local development
+        - Not applicable
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Node version, OS, browser, Docker version, etc.
+      placeholder: |
+        - Node.js: 24.x
+        - OS: Ubuntu 24.04
+        - Browser: Firefox 130
+      render: markdown
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Paste any relevant logs (remove sensitive information).
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and this hasn't been reported yet
+          required: true
+        - label: I'm using the latest version
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/barazo-forum/barazo-api/security/policy
+    about: Please report security vulnerabilities privately via GitHub's security advisory feature. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,55 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea for Barazo? We'd love to hear it. Please describe the problem you're trying to solve and your proposed solution.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this solve? Why is it needed?
+      placeholder: I'm frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How do you think this should work?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you've thought about?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: repo
+    attributes:
+      label: Which component?
+      options:
+        - barazo-api (backend)
+        - barazo-web (frontend)
+        - barazo-lexicons (schemas)
+        - barazo-deploy (Docker/hosting)
+        - barazo-website (docs site)
+        - Not sure
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and this hasn't been requested yet
+          required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,39 @@
+name: Question
+description: Ask a question about Barazo, self-hosting, or the AT Protocol integration
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question? Ask away. For general discussion, you can also use [GitHub Discussions](https://github.com/orgs/barazo-forum/discussions).
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: What would you like to know?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Any relevant context (what you're trying to do, what you've already tried).
+    validations:
+      required: false
+
+  - type: dropdown
+    id: topic
+    attributes:
+      label: Topic area
+      options:
+        - Self-hosting / deployment
+        - AT Protocol / federation
+        - API usage
+        - Frontend / theming
+        - Moderation / admin
+        - Contributing / development
+        - Other
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to Barazo! This document explains ou
 
 ## Code of Conduct
 
-Be respectful, constructive, and collaborative. We're building privacy-focused, open-source forum software for the decentralized web. Everyone is welcome.
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold it. Report unacceptable behavior to conduct@barazo.forum.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary

- Add org-wide issue templates (bug report, feature request, question) that apply to all Barazo repos
- Update CONTRIBUTING.md to reference the formal Code of Conduct
- Disable blank issues; add security policy contact link in template chooser
- Uses YAML form-based templates (not markdown) for structured input

## Templates added

| Template | Labels | Description |
|----------|--------|-------------|
| Bug Report | `bug`, `triage` | Steps to reproduce, environment, logs |
| Feature Request | `enhancement`, `triage` | Problem/solution format |
| Question | `question` | General questions with topic dropdown |

## Test plan

- [ ] Verify templates appear when creating a new issue on any Barazo repo
- [ ] Verify blank issues are disabled
- [ ] Verify security link in template chooser works
- [ ] Verify CoC link in CONTRIBUTING.md resolves correctly