### PR TITLE
docs: update stale test and component counts in profile README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -95,7 +95,7 @@ Traditional forums lock your identity and data into each platform. Barazo uses t
 **Phase 1: Core MVP** -- Done
 - Auth, topics, replies, categories, search, moderation, reactions
 - Cross-posting (Bluesky + Frontpage), notifications, user profiles
-- Frontend (19 pages, 26 components), Docker Compose deployment
+- Frontend (20 pages, 28 components), Docker Compose deployment
 
 **Phase 2: User Experience + Global** -- Done
 - P2.1: Content maturity, self-labels, age gate, user preferences


### PR DESCRIPTION
## Summary

- Update API test count: 885 → 979 (from barazo-api README)
- Update frontend test count: 356 → 411 (from barazo-web README)
- Update frontend scope: 19 pages, 26 components → 20 pages, 28 components (from barazo-web README)

These numbers appear in both the intro paragraph and the Quality/Roadmap sections.