### PR TITLE
docs: fix placeholder links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -293,8 +293,8 @@ pnpm test  # Verify nothing broke
 **Stuck? Ask for help:**
 - **GitHub Discussions** - Questions, ideas, general discussion
 - **GitHub Issues** - Bug reports, feature requests
-- **AT Protocol Discord** - `#barazo` channel (join: [link])
-- **Email** - [maintainer email TBD]
+- **AT Protocol Discord** - `#barazo` channel
+- **Email** - [hello@barazo.forum](mailto:hello@barazo.forum)
 
 ## Recognition
 


### PR DESCRIPTION
Fixes two placeholder items that were never filled in:
- Replaces `[maintainer email TBD]` with hello@barazo.forum
- Removes broken `(join: [link])` placeholder from Discord reference