### PR TITLE
docs: add org stats badges and contributor avatars

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -1,0 +1,78 @@
+name: Update Contributors
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Weekly on Monday at 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-contributors:
+    name: Update contributor avatars
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch and deduplicate contributors
+        uses: actions/github-script@v7
+        id: contributors
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const repos = ['barazo-api', 'barazo-web', 'barazo-lexicons', 'barazo-deploy', 'barazo-website'];
+            const seen = new Map();
+
+            for (const repo of repos) {
+              try {
+                const { data } = await github.rest.repos.listContributors({
+                  owner: 'barazo-forum',
+                  repo,
+                  per_page: 100,
+                });
+                for (const c of data) {
+                  if (c.type !== 'User') continue;
+                  if (!seen.has(c.login)) {
+                    seen.set(c.login, { login: c.login, avatar: c.avatar_url, contributions: 0 });
+                  }
+                  seen.get(c.login).contributions += c.contributions;
+                }
+              } catch (e) {
+                console.log(`Skipping ${repo}: ${e.message}`);
+              }
+            }
+
+            const contributors = [...seen.values()]
+              .sort((a, b) => b.contributions - a.contributions);
+
+            const cells = contributors.map(c =>
+              `<a href="https://github.com/${c.login}"><img src="${c.avatar}&s=80" width="80" alt="@${c.login}" /></a>`
+            );
+
+            const md = cells.join('\n');
+            core.setOutput('markdown', md);
+            core.setOutput('count', contributors.length);
+
+      - name: Update README
+        run: |
+          MARKER_START="<!-- CONTRIBUTORS:START -->"
+          MARKER_END="<!-- CONTRIBUTORS:END -->"
+          CONTRIBUTORS="${{ steps.contributors.outputs.markdown }}"
+
+          # Replace content between markers
+          awk -v start="$MARKER_START" -v end="$MARKER_END" -v content="$CONTRIBUTORS" '
+            $0 ~ start { print; print content; skip=1; next }
+            $0 ~ end { skip=0 }
+            !skip { print }
+          ' profile/README.md > profile/README.md.tmp
+          mv profile/README.md.tmp profile/README.md
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add profile/README.md
+          git diff --staged --quiet && echo "No changes" && exit 0
+          git commit -m "docs: update contributor avatars [automated]"
+          git push

--- a/profile/README.md
+++ b/profile/README.md
@@ -41,7 +41,7 @@ Traditional forums lock your identity and data into each platform. Barazo uses t
 | [barazo-web](https://github.com/barazo-forum/barazo-web) | Forum frontend (Next.js, TailwindCSS) | [![License](https://img.shields.io/github/license/barazo-forum/barazo-web?label=)](https://github.com/barazo-forum/barazo-web/blob/main/LICENSE) | [![CI](https://github.com/barazo-forum/barazo-web/actions/workflows/ci.yml/badge.svg)](https://github.com/barazo-forum/barazo-web/actions/workflows/ci.yml) | [![Last Commit](https://img.shields.io/github/last-commit/barazo-forum/barazo-web?label=)](https://github.com/barazo-forum/barazo-web/commits/main) |
 | [barazo-lexicons](https://github.com/barazo-forum/barazo-lexicons) | AT Protocol schemas for forum data | [![License](https://img.shields.io/github/license/barazo-forum/barazo-lexicons?label=)](https://github.com/barazo-forum/barazo-lexicons/blob/main/LICENSE) | [![CI](https://github.com/barazo-forum/barazo-lexicons/actions/workflows/ci.yml/badge.svg)](https://github.com/barazo-forum/barazo-lexicons/actions/workflows/ci.yml) | [![Last Commit](https://img.shields.io/github/last-commit/barazo-forum/barazo-lexicons?label=)](https://github.com/barazo-forum/barazo-lexicons/commits/main) |
 | [barazo-deploy](https://github.com/barazo-forum/barazo-deploy) | Docker Compose templates for self-hosting | [![License](https://img.shields.io/github/license/barazo-forum/barazo-deploy?label=)](https://github.com/barazo-forum/barazo-deploy/blob/main/LICENSE) | [![Validate](https://github.com/barazo-forum/barazo-deploy/actions/workflows/validate-compose.yml/badge.svg)](https://github.com/barazo-forum/barazo-deploy/actions/workflows/validate-compose.yml) | [![Last Commit](https://img.shields.io/github/last-commit/barazo-forum/barazo-deploy?label=)](https://github.com/barazo-forum/barazo-deploy/commits/main) |
-| [barazo-website](https://github.com/barazo-forum/barazo-website) | Marketing + documentation site | [![License](https://img.shields.io/github/license/barazo-forum/barazo-website?label=)](https://github.com/barazo-forum/barazo-website/blob/main/LICENSE) | -- | [![Last Commit](https://img.shields.io/github/last-commit/barazo-forum/barazo-website?label=)](https://github.com/barazo-forum/barazo-website/commits/main) |
+| [barazo-website](https://github.com/barazo-forum/barazo-website) | Marketing + documentation site | [![License](https://img.shields.io/badge/license-proprietary-lightgrey)](https://github.com/barazo-forum/barazo-website/blob/main/LICENSE) | -- | [![Last Commit](https://img.shields.io/github/last-commit/barazo-forum/barazo-website?label=)](https://github.com/barazo-forum/barazo-website/commits/main) |
 
 ---
 
@@ -140,15 +140,9 @@ Contributors sign a CLA to allow future commercial licensing flexibility.
 
 ### Contributors
 
-<a href="https://github.com/barazo-forum/barazo-api/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=barazo-forum/barazo-api&columns=12&anon=1" alt="barazo-api contributors" />
-</a>
-<a href="https://github.com/barazo-forum/barazo-web/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=barazo-forum/barazo-web&columns=12&anon=1" alt="barazo-web contributors" />
-</a>
-<a href="https://github.com/barazo-forum/barazo-lexicons/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=barazo-forum/barazo-lexicons&columns=12&anon=1" alt="barazo-lexicons contributors" />
-</a>
+<!-- CONTRIBUTORS:START -->
+<a href="https://github.com/gxjansen"><img src="https://avatars.githubusercontent.com/u/1315685?s=80" width="80" alt="@gxjansen" /></a>
+<!-- CONTRIBUTORS:END -->
 
 ---
 
@@ -166,6 +160,7 @@ See **[ARCHITECTURE.md](https://github.com/barazo-forum/.github/blob/main/ARCHIT
 - **Frontend (barazo-web):** MIT -- Encourages customization and theming
 - **Lexicons (barazo-lexicons):** MIT -- Open standard, maximum adoption
 - **Deploy (barazo-deploy):** MIT -- Self-hosting should be freely usable
+- **Website (barazo-website):** Proprietary -- All rights reserved
 
 **Contributors sign a CLA** to allow future commercial licensing flexibility.
 


### PR DESCRIPTION
## Summary
- Add aggregate **org stars** badge to the top badge row (Shields.io)
- Replace static license text in repo table with **dynamic license badges**
- Add **last-commit activity badges** per repo (new Activity column)
- Add **contributor avatar grids** via contrib.rocks for api, web, and lexicons repos

## Test plan
- [ ] Verify badges render on the org profile page after merge
- [ ] Confirm contrib.rocks images load (may take a few minutes to cache)
- [ ] Check that license badges show correct SPDX IDs