### PR TITLE
docs: clarify org stars badge label

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -6,7 +6,7 @@ We build open source software on the [AT Protocol](https://atproto.com). Portabl
 
 Built with 🧡 in 🇪🇺.
 
-[![GitHub Org Stars](https://img.shields.io/github/stars/singi-labs?style=flat&label=org%20stars)](https://github.com/singi-labs)
+[![GitHub Org Stars](https://img.shields.io/github/stars/singi-labs?style=flat&label=total%20org%20stars)](https://github.com/singi-labs)
 [![Website](https://img.shields.io/badge/singi.dev-website-DA702C)](https://singi.dev)
 
 ---


### PR DESCRIPTION
## Summary
- Update shields.io badge label from "org stars" to "total org stars" to clarify that the count is the sum of stars across all repos (GitHub orgs have followers, not stars)

## Changes
- `profile/README.md`: Updated badge label parameter

## Test plan
- [ ] Badge renders correctly on the org profile page