### PR TITLE
docs: remove stale backend/frontend from Sifa license line

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -41,8 +41,6 @@ Professional identity and career network on the AT Protocol. Portable profiles, 
 
 | Repository | Description | CI | Updated |
 |------------|-------------|----|---------|
-| [sifa-api](https://github.com/singi-labs/sifa-api) | AppView backend (Fastify, AT Protocol, Jetstream) | [![CI](https://github.com/singi-labs/sifa-api/actions/workflows/ci.yml/badge.svg)](https://github.com/singi-labs/sifa-api/actions/workflows/ci.yml) | ![Updated](https://img.shields.io/github/last-commit/singi-labs/sifa-api?label=updated) |
-| [sifa-web](https://github.com/singi-labs/sifa-web) | Frontend (Next.js, React, TailwindCSS) | [![CI](https://github.com/singi-labs/sifa-web/actions/workflows/ci.yml/badge.svg)](https://github.com/singi-labs/sifa-web/actions/workflows/ci.yml) | ![Updated](https://img.shields.io/github/last-commit/singi-labs/sifa-web?label=updated) |
 | [sifa-lexicons](https://github.com/singi-labs/sifa-lexicons) | AT Protocol professional profile schemas (MIT) | [![Validate](https://github.com/singi-labs/sifa-lexicons/actions/workflows/validate.yml/badge.svg)](https://github.com/singi-labs/sifa-lexicons/actions/workflows/validate.yml) | ![Updated](https://img.shields.io/github/last-commit/singi-labs/sifa-lexicons?label=updated) |
 
 [sifa.id](https://sifa.id)

--- a/profile/README.md
+++ b/profile/README.md
@@ -37,7 +37,7 @@ Federated forums on the AT Protocol. Self-hostable. One account works across eve
 Professional identity and career network on the AT Protocol. Portable profiles, verifiable track record from real community contributions, no vendor lock-in. The LinkedIn alternative for the decentralized web.
 
 **Status:** Alpha (P1 MVP complete)
-**License:** Source-available (backend, frontend) + MIT (lexicons)
+**License:** Source-available + MIT (lexicons)
 
 | Repository | Description | CI | Updated |
 |------------|-------------|----|---------|


### PR DESCRIPTION
## Summary
- Follow-up to #23: removed the "(backend, frontend)" parenthetical from the Sifa license line since those repos are now private and no longer listed