### PR TITLE
docs: fix Sifa license to MIT only

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -37,7 +37,7 @@ Federated forums on the AT Protocol. Self-hostable. One account works across eve
 Professional identity and career network on the AT Protocol. Portable profiles, verifiable track record from real community contributions, no vendor lock-in. The LinkedIn alternative for the decentralized web.
 
 **Status:** Alpha (P1 MVP complete)
-**License:** Source-available + MIT (lexicons)
+**License:** MIT (lexicons)
 
 | Repository | Description | CI | Updated |
 |------------|-------------|----|---------|


### PR DESCRIPTION
## Summary
- Follow-up to #24: removed "Source-available" from Sifa license line -- no public source-available repos remain after making sifa-api and sifa-web private
- License is now just MIT (lexicons)