### PR TITLE
docs: remove GitHub Discussions references

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Have a question? Ask away. For general discussion, you can also use [GitHub Discussions](https://github.com/orgs/singi-labs/discussions).
+        Have a question? Ask away. You can also reach us on Bluesky [@singi.dev](https://bsky.app/profile/singi.dev).
 
   - type: textarea
     id: question


### PR DESCRIPTION
## Summary

- We never enabled GitHub Discussions on the `singi-labs` org, so every link pointing there 404s.
- `CONTRIBUTING.md` "Getting Help" section now points to Bluesky (@singi.dev / @barazo.forum / @sifa.id) instead of Discussions.
- `question.yml` issue template no longer suggests Discussions; suggests Bluesky as the informal channel instead.

## Test plan

- [x] Visual review of rendered `CONTRIBUTING.md` and issue template
- [ ] After merge: confirm no remaining "GitHub Discussions" references in repo (paired sweep across 13 other repos)