### PR TITLE
docs(cla): org-wide CLA with no-equity and confidentiality clauses

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,42 +1,92 @@
-# Barazo Contributor License Agreement
+# Singi Labs Contributor License Agreement
 
-Thank you for your interest in contributing to Barazo ("We" or "Us").
+Thank you for your interest in contributing to a Singi Labs project ("We" or "Us").
 
-This Contributor License Agreement ("Agreement") documents the rights granted by contributors to Us.
+This Contributor License Agreement ("Agreement") documents the rights granted by
+contributors to Us. It applies to every repository in the `singi-labs` GitHub
+organization, regardless of that repository's open-source, source-available, or
+proprietary license.
 
 ## 1. Definitions
 
 "You" means the individual who submits a Contribution to Us.
 
-"Contribution" means any work of authorship that is submitted by You to Us in which You own or assert ownership of the Copyright.
+"Contribution" means any work of authorship that is submitted by You to Us in
+which You own or assert ownership of the Copyright.
 
-"Copyright" means all rights protecting works of authorship owned or controlled by You, including copyright, moral and neighboring rights, as appropriate.
+"Copyright" means all rights protecting works of authorship owned or controlled
+by You, including copyright, moral and neighboring rights, as appropriate.
 
-"Submit" means any form of electronic, verbal, or written communication sent to Us or our representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems.
+"Submit" means any form of electronic, verbal, or written communication sent to
+Us or our representatives, including but not limited to communication on
+electronic mailing lists, source code control systems, and issue tracking
+systems.
 
 ## 2. Grant of Rights
 
 ### 2.1 Copyright License
 
-You grant Us a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable license under the Copyright covering the Contribution, with the right to sublicense such rights through multiple tiers of sublicensees, to reproduce, modify, display, perform and distribute the Contribution as part of the Project.
+You grant Us a perpetual, worldwide, non-exclusive, transferable, royalty-free,
+irrevocable license under the Copyright covering the Contribution, with the
+right to sublicense such rights through multiple tiers of sublicensees, to
+reproduce, modify, display, perform and distribute the Contribution as part of
+the Project, and to relicense the Contribution under any license terms We
+choose, including proprietary or source-available terms.
 
 ### 2.2 Patent License
 
-You grant Us a perpetual, worldwide, non-exclusive, transferable, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Contribution and the Contribution in combination with the Project.
+You grant Us a perpetual, worldwide, non-exclusive, transferable, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Contribution
+and the Contribution in combination with the Project.
 
 ## 3. Your Representations
 
 You represent that:
 
-1. You are legally entitled to grant the above license
-2. The Contribution is Your original creation
-3. You have not granted and will not grant rights in the Contribution to a third party that would conflict with the license granted to Us
+1. You are legally entitled to grant the above license.
+2. The Contribution is Your original creation.
+3. You have not granted and will not grant rights in the Contribution to a
+   third party that would conflict with the license granted to Us.
+4. If Your employer has rights to intellectual property You create, You have
+   received permission to make the Contribution on behalf of that employer, or
+   that employer has waived such rights for the Contribution.
 
-## 4. No Obligation
+## 4. No Compensation, Equity, or Ownership Interest
 
-You are not expected or required to provide support for Your Contributions, except to the extent You desire to provide support. You may provide support for free, for a fee, or not at all.
+You acknowledge and agree that:
 
-## 5. Effective Date
+1. Your Contributions are made voluntarily and gratuitously.
+2. This Agreement does not entitle You to any payment, compensation, fee,
+   royalty, equity, shares, revenue share, or profit participation in Singi
+   Labs, any Singi Labs product, or any associated entity, whether now or in
+   the future.
+3. Contributing does not create any partnership, joint venture, agency,
+   employment, or co-ownership relationship between You and Us.
+4. You retain ownership of Your underlying Copyright (subject to the license
+   granted in Section 2) but acquire no ownership interest in any Singi Labs
+   project, codebase, brand, or business as a result of contributing.
+
+## 5. Confidentiality (pre-release projects)
+
+Some repositories are private and pre-release. While a repository remains
+private, You agree not to publicly disclose its non-public source code, security
+designs, infrastructure details, or any user data You access through it before
+that material is publicly released by Us. This obligation ends for any material
+once We make it public (for example, by open-sourcing the project).
+
+## 6. No Obligation
+
+You are not expected or required to provide support for Your Contributions,
+except to the extent You desire to provide support. We are under no obligation
+to accept, merge, or use any Contribution.
+
+## 7. Disclaimer
+
+Unless required by applicable law or agreed to in writing, You provide Your
+Contributions on an "AS IS" basis, without warranties or conditions of any kind.
+
+## 8. Effective Date
 
 This Agreement becomes effective on the date You sign it.
 


### PR DESCRIPTION
Updates the org CLA from Barazo-only to cover all Singi Labs products.

Changes:
- Retitle to 'Singi Labs Contributor License Agreement', applies org-wide.
- §2.1: add explicit relicense right (needed for source-available/proprietary repos).
- §3.4: add employer-IP representation.
- §4 (new): no compensation, equity, or ownership interest.
- §5 (new): confidentiality for private/pre-release repos, self-expiring on public release.

Reference document for the CLA Assistant workflow being added to sifa-web/api/sdk.