### PR TITLE
feat(ci): canonical AI reviewer + reusable workflow (backend/frontend profiles)

### DIFF
--- a/.github/workflows/ai-review-reusable.yml
+++ b/.github/workflows/ai-review-reusable.yml
@@ -1,0 +1,142 @@
+name: AI PR Review (reusable)
+
+# Org-wide reusable AI code reviewer. Each repo calls this with a 5-line caller
+# workflow; the engine + prompts live ONCE here in singi-labs/.github.
+#
+# Posts a comment + a BLOCKING "AI Review" status (fails on request_changes).
+# Always posts the status (skip/bot/error -> success) so a required check never
+# jams. Fails OPEN on reviewer/infra error. See scripts/ai-review/README.md.
+
+on:
+  workflow_call:
+    inputs:
+      profile:
+        description: "Prompt set: backend | frontend"
+        type: string
+        default: backend
+    secrets:
+      OPENROUTER_API_KEY:
+        required: true
+
+env:
+  GENERAL_MODEL: moonshotai/kimi-k2.7-code
+  ADVERSARIAL_MODEL: z-ai/glm-5.2
+
+jobs:
+  review:
+    if: >-
+      ${{ github.event.pull_request.draft == false &&
+      (github.event.action != 'labeled' ||
+       github.event.label.name == 'deep-review' ||
+       github.event.label.name == 're-review') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
+    steps:
+      - name: Check out caller repo (PR code, for CLAUDE.md)
+        uses: actions/checkout@v4
+
+      - name: Check out reviewer (singi-labs/.github)
+        uses: actions/checkout@v4
+        with:
+          repository: singi-labs/.github
+          path: .singi-review
+
+      - name: Select prompts for profile
+        id: prof
+        run: |
+          if [ "${{ inputs.profile }}" = "frontend" ]; then
+            echo "general=general.frontend.md" >> "$GITHUB_OUTPUT"
+            echo "adversarial=adversarial.frontend.md" >> "$GITHUB_OUTPUT"
+          else
+            echo "general=general.md" >> "$GITHUB_OUTPUT"
+            echo "adversarial=adversarial.md" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Scope & fetch diff
+        id: scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          set -euo pipefail
+          case "$AUTHOR" in
+            *"[bot]"|dependabot) echo "skip=true" >> "$GITHUB_OUTPUT"; echo "Skipping: bot author ($AUTHOR)"; exit 0;;
+          esac
+          files=$(gh pr diff "$PR" --name-only)
+          nontrivial=$(printf '%s\n' "$files" | grep -vE '(^|/)(docs/|.*\.md$|\.github/|.*\.lock$|.*lock\.json$|.*lock\.ya?ml$|.*\.snap$|LICENSE.*|.*\.txt$)' || true)
+          if [ -z "$(printf '%s' "$nontrivial" | tr -d '[:space:]')" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"; echo "Skipping: only trivial files changed"; exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          gh pr diff "$PR" --patch > diff.patch
+          lines=$(wc -l < diff.patch)
+          mode=single
+          printf '%s' "$LABELS" | grep -q 'deep-review' && mode=dual || true
+          [ "$lines" -gt 800 ] && mode=dual || true
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+          echo "Scoped: profile=${{ inputs.profile }}, mode=$mode, diff lines=$lines"
+
+      - name: Run AI review
+        if: steps.scope.outputs.skip != 'true'
+        id: run
+        continue-on-error: true
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          AI_REVIEW_MODE: ${{ steps.scope.outputs.mode }}
+          GENERAL_MODEL: ${{ env.GENERAL_MODEL }}
+          ADVERSARIAL_MODEL: ${{ env.ADVERSARIAL_MODEL }}
+          GENERAL_PROMPT: ${{ steps.prof.outputs.general }}
+          ADVERSARIAL_PROMPT: ${{ steps.prof.outputs.adversarial }}
+          DIFF_FILE: diff.patch
+          STANDARDS_FILE: CLAUDE.md
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: node .singi-review/scripts/ai-review/review.mjs > review.md
+
+      - name: Post review comment
+        if: steps.scope.outputs.skip != 'true' && steps.run.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          body="$(cat review.md)"
+          existing=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+            --jq '.[] | select(.body | contains("<!-- ai-review -->")) | .id' | head -1)
+          if [ -n "${existing:-}" ]; then
+            gh api -X PATCH "repos/$REPO/issues/comments/$existing" -f body="$body" >/dev/null
+            echo "Updated comment $existing"
+          else
+            gh pr comment "$PR" --body "$body"
+          fi
+
+      - name: Report AI Review status
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+          SKIP: ${{ steps.scope.outputs.skip }}
+          OUTCOME: ${{ steps.run.outcome }}
+          VERDICT: ${{ steps.run.outputs.verdict }}
+          SUMMARY: ${{ steps.run.outputs.summary }}
+        run: |
+          set -euo pipefail
+          if [ "$SKIP" = "true" ]; then
+            state=success; desc="Skipped (trivial or bot PR)"
+          elif [ "$OUTCOME" != "success" ]; then
+            state=success; desc="Reviewer unavailable — failing open"
+          elif [ "$VERDICT" = "request_changes" ]; then
+            state=failure; desc="Changes requested — ${SUMMARY:-see comment}"
+          else
+            state=success; desc="${SUMMARY:-reviewed}"
+          fi
+          gh api -X POST "repos/$REPO/statuses/$SHA" \
+            -f state="$state" -f context="AI Review" -f description="$desc" >/dev/null
+          echo "AI Review status: $state — $desc"

--- a/scripts/ai-review/README.md
+++ b/scripts/ai-review/README.md
@@ -1,0 +1,102 @@
+# AI PR Review
+
+Self-owned, token-based AI code review — our replacement for CodeRabbit. Runs in
+CI on every PR, posts a review comment, and reports a **blocking** `AI Review`
+status check — the check fails (gating merge) when a reviewer requests changes.
+Pay-per-token via OpenRouter; **$0 when no PRs**, no per-seat fee.
+
+**This is the canonical home.** The engine (`review.mjs`) and prompts live here in
+`singi-labs/.github` and are run via the reusable workflow
+`.github/workflows/ai-review-reusable.yml`. Each repo wires it up with a tiny
+caller:
+
+```yaml
+# <repo>/.github/workflows/ai-review.yml
+name: AI PR Review
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, labeled]
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+jobs:
+  review:
+    uses: singi-labs/.github/.github/workflows/ai-review-reusable.yml@main
+    secrets: inherit
+    with:
+      profile: backend # or: frontend (sifa-web)
+```
+
+**Profiles** select the prompt set: `backend` → `prompts/general.md` +
+`adversarial.md`; `frontend` → `prompts/general.frontend.md` +
+`adversarial.frontend.md`. Add new profiles by adding prompt files and a case in
+the reusable workflow's "Select prompts" step.
+
+## How it works
+
+1. **`.github/workflows/ai-review.yml`** triggers on PR **open / reopen / push
+   (synchronize) / ready**, plus the `deep-review` / `re-review` labels. It
+   re-reviews on each push so a flagged PR can recover after fixes (required for
+   a blocking gate). Concurrency cancels superseded runs so you don't pay twice.
+2. It **scopes** the PR — skips drafts, bot authors, and trivial-only PRs
+   (docs, `*.md`, `.github/`, lockfiles, snapshots).
+3. It picks a **mode**: `single` (one general pass) by default, or `dual`
+   (general + adversarial) when the PR has the `deep-review` label or a large
+   diff (>800 lines).
+4. **`review.mjs`** sends the diff + PR context + project standards to OpenRouter,
+   gets structured JSON findings, and renders a Markdown report.
+5. The workflow **upserts one PR comment** (updated in place on re-runs) and
+   sets the **blocking** `AI Review` status: `failure` on `request_changes`
+   (critical/major), `success` otherwise. Skip/bot/error paths always post
+   `success` so the required check never jams (fails open on reviewer error).
+
+**Re-review:** add the `re-review` label to re-run on the latest commit (toggle
+it off/on to trigger again), or `deep-review` for a dual pass.
+
+**Make it enforce:** mark `AI Review` as a required status check on the branch.
+
+## Reviewers
+
+- **General** (`prompts/general.md`) — correctness, standards, tests,
+  maintainability. Default model: `moonshotai/kimi-k2.7-code` (code-specialized).
+- **Adversarial** (`prompts/adversarial.md`) — security, edge cases, races,
+  failure modes. Tries to _break_ the PR. Default model: `z-ai/glm-5.2`.
+
+Both are cheap, coding-specialized models. Swap via the `GENERAL_MODEL` /
+`ADVERSARIAL_MODEL` env in the workflow.
+
+## Setup
+
+Add an org (or repo) secret **`OPENROUTER_API_KEY`** scoped to this repo.
+Nothing else — no app install, no marketplace action, no npm deps (the script
+uses Node's built-in `fetch`).
+
+## Config (env consumed by `review.mjs`)
+
+| Var                    | Default                     | Purpose                                         |
+| ---------------------- | --------------------------- | ----------------------------------------------- |
+| `OPENROUTER_API_KEY`   | —                           | required                                        |
+| `AI_REVIEW_MODE`       | `single`                    | `single` or `dual`                              |
+| `GENERAL_MODEL`        | `moonshotai/kimi-k2.7-code` | first-pass model                                |
+| `ADVERSARIAL_MODEL`    | `z-ai/glm-5.2`              | second-pass model (dual only)                   |
+| `DIFF_FILE`            | —                           | path to the unified diff                        |
+| `STANDARDS_FILE`       | —                           | path to standards excerpt (we pass `CLAUDE.md`) |
+| `PR_TITLE` / `PR_BODY` | —                           | PR context                                      |
+| `MAX_DIFF_CHARS`       | `120000`                    | diff truncation cap (cost control)              |
+
+## Cost control
+
+- Re-reviews on each push (needed for a blocking gate), but concurrency cancels superseded runs.
+- Single cheap pass by default; dual only on demand (`deep-review` label) or big diffs.
+- Trivial PRs and bot PRs skipped entirely.
+- Diff truncated past `MAX_DIFF_CHARS`.
+- Daily spend backstopped by the OpenRouter key's own cap.
+
+## Roadmap
+
+- **Phase 1 (now):** blocking gate — `AI Review` fails on `request_changes`.
+  Mark it required on each branch to enforce.
+- **Phase 2:** wire the verdict into `singi-implement-next-prio` so the agent
+  auto-iterates until the reviewers approve (the "general + adversarial,
+  iterate-until-pass" loop), and promote to an org reusable workflow for web/sdk.

--- a/scripts/ai-review/prompts/adversarial.frontend.md
+++ b/scripts/ai-review/prompts/adversarial.frontend.md
@@ -1,0 +1,28 @@
+You are a skeptical frontend security and reliability engineer trying to BREAK
+this pull request before it ships. Assume the code is wrong until proven
+otherwise. This is a Next.js (App Router) / React app on the AT Protocol —
+hostile input, untrusted profile content, and flaky networks are a given.
+
+Hunt specifically for:
+
+1. **XSS & injection** — `dangerouslySetInnerHTML` without sanitization, unsanitized
+   user/profile content rendered as HTML/markdown, `javascript:`/`data:` URLs in
+   `href`/`src`, untrusted values in inline styles or `srcdoc`.
+2. **Secret / data leakage to the client** — server-only secrets, tokens, or PII
+   imported into Client Components or `NEXT_PUBLIC_` env; over-fetching that ships
+   private fields to the browser; tokens in `localStorage`/`sessionStorage`
+   (access tokens belong in memory, refresh tokens in HTTP-only cookies).
+3. **Auth / identity** — trusting client-supplied DIDs/handles without server
+   verification; missing authz checks before showing/acting on another user's data;
+   open redirects from user-controlled `next`/`returnTo` params.
+4. **Reliability** — unhandled fetch failures, missing loading/error/empty states,
+   hydration mismatches, infinite render/`useEffect` loops, unbounded lists without
+   virtualization, layout shift, requests with no timeout/abort.
+5. **Edge cases** — empty/huge/unicode/bidi content, missing-image fallbacks,
+   pagination boundaries, double-submit on forms, optimistic updates that don't
+   roll back on error.
+
+For each issue, describe the concrete scenario or input that triggers it, not just
+a category. Cite file and line. If you genuinely cannot break it, say so and
+approve — do not manufacture findings. Prioritize a few real, exploitable problems
+over a long list of theoretical ones.

--- a/scripts/ai-review/prompts/adversarial.md
+++ b/scripts/ai-review/prompts/adversarial.md
@@ -1,0 +1,48 @@
+You are a skeptical security and reliability engineer trying to BREAK this pull
+request before it reaches production. Assume the code is wrong until proven
+otherwise. This is an AT Protocol service (Fastify API, PostgreSQL + Drizzle,
+Valkey, OAuth) — attackers and malformed data are a given.
+
+Hunt specifically for:
+
+1. **Security** — injection (SQL/command/path), missing or weak input validation,
+   authz gaps (can user A act on user B's data?), secrets/PII leaking into logs
+   or responses, SSRF, unsafe deserialization, OAuth/token mishandling, app
+   passwords used where OAuth is required.
+2. **Edge cases** — empty/null/huge inputs, unicode, timezone/locale, pagination
+   boundaries, concurrent writes, partial failures, retries that double-apply.
+3. **Race conditions & state** — TOCTOU, unawaited promises, shared mutable
+   state, cache/DB inconsistency, non-idempotent operations that get retried.
+4. **Failure modes** — what happens when the PDS / DB / Valkey is slow, down, or
+   returns garbage? Unbounded retries? Missing timeouts? Swallowed errors?
+5. **Resource & abuse** — unbounded loops/queries, N+1, memory blowups, missing
+   rate limits on expensive paths.
+
+Singi-specific attack surface to check:
+
+- **Identity:** resolve/verify the actor's DID on each request and fail CLOSED if
+  resolution fails. Never trust a client-supplied DID without verification.
+- **Tokens & secrets:** OAuth refresh tokens belong in HTTP-only, Secure,
+  SameSite=Strict cookies; access tokens in memory only — never
+  localStorage/sessionStorage, never logged, never cached raw. Secrets at rest
+  encrypted. Flag any secret/token/PII reaching logs or responses.
+- **Lexicon/record validation:** validate every incoming AT Protocol record
+  (including firehose) before indexing (`validate: true` for our own lexicons);
+  use `com.atproto.repo.strongRef` for record references; correct record-key type
+  (`tid` default, `literal:self` for singletons).
+- **Sanitization:** user content sanitized with a restrictive DOMPurify config
+  (explicit allow-lists; strip event handlers and `javascript:`/`data:` URIs);
+  pipeline order markdown → HTML → DOMPurify. Normalize input to NFC and strip
+  bidirectional/control chars (U+202A–U+202E, U+2066–U+2069) before validation.
+- **Rate limiting:** auth, write, and expensive endpoints must be rate-limited
+  (stricter for new accounts); flag unbounded or unprotected ones.
+- **Deletion:** account/record deletion must invalidate all sessions for that DID
+  and purge cached data; handle the firehose `#account` deletion event (the
+  deprecated `#tombstone` must NOT be used).
+- **Idempotency:** retryable writes (firehose, webhooks, callbacks) must be
+  idempotent — flag double-apply risks.
+
+For each issue, describe the concrete scenario that triggers it (the attack or
+the input), not just a category. Cite file and line. If you genuinely cannot
+break it, say so and approve — do not manufacture findings. Prioritize a small
+number of real, exploitable problems over a long list of theoretical ones.

--- a/scripts/ai-review/prompts/general.frontend.md
+++ b/scripts/ai-review/prompts/general.frontend.md
@@ -1,0 +1,29 @@
+You are a senior frontend engineer reviewing a pull request for a Next.js
+(App Router) / React / TypeScript / TailwindCSS / shadcn-ui codebase on the AT
+Protocol. You are the independent reviewer — the author is an AI coding agent, so
+do not assume the code is correct; verify it.
+
+Focus, in priority order:
+
+1. **Correctness** — broken hooks rules, missing deps in `useEffect`/`useMemo`,
+   stale closures, unhandled loading/error states, incorrect data fetching,
+   hydration mismatches, race conditions in async UI.
+2. **Server vs Client boundaries** — keep components Server Components by default;
+   `"use client"` only when actually needed (state, effects, browser APIs, event
+   handlers). Flag client components that could be server, and secrets/server-only
+   data leaking into client bundles.
+3. **Accessibility (WCAG 2.2 AA)** — semantic HTML (`<button>`, not `<div onClick>`),
+   keyboard navigability, visible focus, labels/`aria-*` where needed, alt text,
+   color-contrast, no focus traps.
+4. **Standards compliance** — TypeScript strict (no `any`, no `@ts-ignore`); no
+   `console.*`; validate external/URL/search-param input with Zod.
+5. **Design system** — reuse existing `src/components/ui/` primitives before adding
+   new ones; use design tokens, never literal hex colors or one-off spacing;
+   Phosphor icons; no inline styles where a token/class exists.
+6. **Tests** — co-located `*.test.tsx`; component behavior + a11y (vitest-axe)
+   covered for non-trivial UI.
+
+Be specific: cite the file and line, explain _why_ it matters, and give a concrete
+fix. Report only real, actionable issues from THIS diff — do not pad the list. A
+clean PR comes back approved with no findings. Keep nits few; lead with what
+actually matters (correctness, boundaries, a11y).

--- a/scripts/ai-review/prompts/general.md
+++ b/scripts/ai-review/prompts/general.md
@@ -1,0 +1,42 @@
+You are a senior engineer reviewing a pull request for a TypeScript/Node.js
+codebase built on the AT Protocol (Fastify API, PostgreSQL + Drizzle, Valkey).
+You are the independent reviewer — the author is an AI coding agent, so do not
+assume the code is correct; verify it.
+
+Focus, in priority order:
+
+1. **Correctness** — logic bugs, wrong conditions, off-by-one, unhandled error
+   paths, broken async/await, incorrect types, data that won't round-trip.
+2. **Standards compliance** — TypeScript strict (no `any`, no `@ts-ignore`);
+   Zod validation on every external input; output sanitized; no `console.log`
+   (use the project logger); AT Protocol auth via OAuth, never app passwords.
+3. **Tests** — is new logic covered? Are edge cases tested? Flag missing tests
+   for non-trivial behavior.
+4. **Maintainability** — needless complexity, duplication, unclear naming, dead
+   code. Prefer the boring, well-understood pattern.
+5. **Accessibility** (if UI) — semantic HTML, keyboard nav, ARIA where needed.
+
+Singi-specific rules to enforce on the diff:
+
+- **TypeScript:** no `any`, no `@ts-ignore`; every `as` cast needs an explanatory
+  comment; guard array/record access (`noUncheckedIndexedAccess` is on).
+- **Validation:** Zod at every boundary — API inputs, env vars (fail-fast at
+  startup), and AT Protocol records. Derive types from the Zod schema; flag
+  parallel hand-written types that can drift out of sync.
+- **Logging:** no `console.*` — use the Pino logger.
+- **Fastify response schemas:** error responses must declare `error`, `message`,
+  and `statusCode` (a missing field silently drops data). Nullable/optional
+  fields use `type: ["string","null"]` / Zod `.nullable().optional()`, never a
+  bare `type: "string"`.
+- **Authorization parity:** access-control checks must be consistent across the
+  list, single-GET, write, and nested-resource variants of a resource — flag a
+  gate present on one but missing on another.
+- **Tests:** new/changed logic needs a co-located `*.test.ts`; aim 80%+ coverage.
+  Mocks for multi-export modules use `importOriginal` partial mocks, not full
+  replacement.
+- **IDs:** generate with `crypto.randomUUID()`, never `Math.random()`.
+
+Be specific: cite the file and line, explain _why_ it matters, and give a
+concrete fix when you can. Report only real, actionable issues from THIS diff —
+do not pad the list. A clean PR should come back approved with no findings.
+Keep nits few; lead with what actually matters.

--- a/scripts/ai-review/review.mjs
+++ b/scripts/ai-review/review.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+// AI PR reviewer — dependency-free, OpenRouter-backed.
+//
+// Reads a unified diff + PR context, asks one (general) or two (general +
+// adversarial) LLM reviewers for STRUCTURED findings, prints a Markdown report
+// to stdout, and writes machine outputs (verdict + counts) to $GITHUB_OUTPUT.
+//
+// All config via env (see scripts/ai-review/README.md). No npm deps: uses the
+// Node 20+ global fetch. The workflow handles posting the comment + status.
+
+import { readFileSync, existsSync, appendFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const API = "https://openrouter.ai/api/v1/chat/completions";
+const env = process.env;
+
+const KEY = env.OPENROUTER_API_KEY;
+if (!KEY) {
+  console.error("OPENROUTER_API_KEY is not set");
+  process.exit(1);
+}
+
+const MODE = (env.AI_REVIEW_MODE || "single").toLowerCase();
+const GENERAL_MODEL = env.GENERAL_MODEL || "moonshotai/kimi-k2.7-code";
+const ADVERSARIAL_MODEL = env.ADVERSARIAL_MODEL || "z-ai/glm-5.2";
+const MAX_DIFF = parseInt(env.MAX_DIFF_CHARS || "120000", 10);
+
+const rawDiff =
+  env.DIFF_FILE && existsSync(env.DIFF_FILE)
+    ? readFileSync(env.DIFF_FILE, "utf8")
+    : "";
+if (!rawDiff.trim()) {
+  console.error("Diff is empty — nothing to review");
+  process.exit(1);
+}
+const truncated = rawDiff.length > MAX_DIFF;
+const diff = truncated ? rawDiff.slice(0, MAX_DIFF) : rawDiff;
+
+const standards =
+  env.STANDARDS_FILE && existsSync(env.STANDARDS_FILE)
+    ? readFileSync(env.STANDARDS_FILE, "utf8").slice(0, 8000)
+    : "";
+const prTitle = env.PR_TITLE || "";
+const prBody = (env.PR_BODY || "").slice(0, 4000);
+
+const loadPrompt = (name) => readFileSync(join(HERE, "prompts", name), "utf8");
+
+const SCHEMA = `
+Respond with ONLY a single JSON object — no prose, no markdown fences:
+{
+  "verdict": "approve" | "comment" | "request_changes",
+  "summary": "1-3 sentence overall assessment",
+  "findings": [
+    {
+      "severity": "critical" | "major" | "minor" | "nit",
+      "category": "bug" | "security" | "perf" | "types" | "test" | "a11y" | "style" | "other",
+      "file": "path/to/file",
+      "line": 0,
+      "title": "short headline",
+      "detail": "what is wrong and why it matters",
+      "suggestion": "concrete fix (optional, omit if none)"
+    }
+  ]
+}
+Rules: only report real, actionable issues from THIS diff — do not invent problems to
+look busy. No findings => "verdict": "approve" and empty "findings". Use
+"request_changes" only when at least one critical or major issue exists.`;
+
+const RANK = { approve: 0, comment: 1, request_changes: 2 };
+const SEV_ORDER = ["critical", "major", "minor", "nit"];
+const SEV_EMOJI = { critical: "🔴", major: "🟠", minor: "🟡", nit: "⚪" };
+
+function extractJson(text) {
+  if (!text) return null;
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start === -1 || end <= start) return null;
+  try {
+    return JSON.parse(text.slice(start, end + 1));
+  } catch {
+    return null;
+  }
+}
+
+function normalize(obj) {
+  const o = obj || {};
+  const verdict = ["approve", "comment", "request_changes"].includes(o.verdict)
+    ? o.verdict
+    : "comment";
+  const findings = Array.isArray(o.findings)
+    ? o.findings.filter((f) => f && f.title)
+    : [];
+  return { verdict, summary: (o.summary || "").toString().trim(), findings };
+}
+
+async function runReviewer(name, model, systemPrompt) {
+  const system = `${systemPrompt}\n\n${standards ? `Project engineering standards (excerpt):\n${standards}\n\n` : ""}${SCHEMA}`;
+  const user = `PR title: ${prTitle}\n\nPR description:\n${prBody || "(none)"}\n\nUnified diff${truncated ? " (TRUNCATED — large PR)" : ""}:\n\`\`\`diff\n${diff}\n\`\`\``;
+  const res = await fetch(API, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${KEY}`,
+      "Content-Type": "application/json",
+      "HTTP-Referer": "https://github.com/singi-labs",
+      "X-Title": "Singi AI PR Review",
+    },
+    body: JSON.stringify({
+      model,
+      temperature: 0.1,
+      max_tokens: 4000,
+      messages: [
+        { role: "system", content: system },
+        { role: "user", content: user },
+      ],
+    }),
+  });
+  if (!res.ok)
+    throw new Error(
+      `${name} (${model}) HTTP ${res.status}: ${(await res.text()).slice(0, 300)}`,
+    );
+  const data = await res.json();
+  const content = data.choices?.[0]?.message?.content || "";
+  return { name, model, ...normalize(extractJson(content)) };
+}
+
+function renderFindings(findings) {
+  if (!findings.length) return "_No issues found._\n";
+  const sorted = [...findings].sort(
+    (a, b) => SEV_ORDER.indexOf(a.severity) - SEV_ORDER.indexOf(b.severity),
+  );
+  return sorted
+    .map((f) => {
+      const sev = SEV_EMOJI[f.severity] || "⚪";
+      const loc = f.file ? ` \`${f.file}${f.line ? `:${f.line}` : ""}\`` : "";
+      const cat = f.category ? ` _(${f.category})_` : "";
+      const sug = f.suggestion ? `\n  - **Fix:** ${f.suggestion}` : "";
+      return `- ${sev} **${f.title}**${loc}${cat}\n  - ${f.detail || ""}${sug}`;
+    })
+    .join("\n");
+}
+
+(async () => {
+  // Prompt files are env-selectable so one engine serves multiple profiles
+  // (e.g. backend vs frontend). Defaults keep backward compatibility.
+  const reviewers = [
+    {
+      name: "General",
+      model: GENERAL_MODEL,
+      prompt: loadPrompt(env.GENERAL_PROMPT || "general.md"),
+    },
+  ];
+  if (MODE === "dual")
+    reviewers.push({
+      name: "Adversarial",
+      model: ADVERSARIAL_MODEL,
+      prompt: loadPrompt(env.ADVERSARIAL_PROMPT || "adversarial.md"),
+    });
+
+  const results = await Promise.all(
+    reviewers.map((r) =>
+      runReviewer(r.name, r.model, r.prompt).catch((e) => ({
+        name: r.name,
+        model: r.model,
+        error: e.message,
+        verdict: "comment",
+        summary: "",
+        findings: [],
+      })),
+    ),
+  );
+
+  const allFindings = results.flatMap((r) => r.findings);
+  let worst = results.reduce(
+    (w, r) => (RANK[r.verdict] > RANK[w] ? r.verdict : w),
+    "approve",
+  );
+  const counts = SEV_ORDER.reduce(
+    (acc, s) => ({
+      ...acc,
+      [s]: allFindings.filter((f) => f.severity === s).length,
+    }),
+    {},
+  );
+  const total = allFindings.length;
+  if (total === 0) worst = "approve";
+
+  // ---- Markdown report (stdout -> posted as PR comment by the workflow) ----
+  const verdictBadge = {
+    approve: "✅ Approve",
+    comment: "💬 Comments",
+    request_changes: "🔴 Changes requested",
+  }[worst];
+  const lines = [];
+  lines.push("<!-- ai-review -->");
+  lines.push("## 🤖 AI code review");
+  lines.push("");
+  lines.push(
+    `**Verdict:** ${verdictBadge}  ·  **Findings:** ${total} (🔴 ${counts.critical} · 🟠 ${counts.major} · 🟡 ${counts.minor} · ⚪ ${counts.nit})`,
+  );
+  lines.push("");
+  for (const r of results) {
+    lines.push(`### ${r.name} reviewer · \`${r.model}\``);
+    if (r.error) {
+      lines.push(`> ⚠️ reviewer failed: ${r.error}`);
+      lines.push("");
+      continue;
+    }
+    if (r.summary) lines.push(`> ${r.summary}`);
+    lines.push("");
+    lines.push(renderFindings(r.findings));
+    lines.push("");
+  }
+  if (truncated)
+    lines.push(
+      "> ℹ️ Diff was truncated for size — review covers the first part only.",
+    );
+  lines.push("");
+  lines.push(
+    `<sub>Blocking when changes are requested. Token-based via OpenRouter. Re-runs on each push — add the \`re-review\` label to force a re-run, or \`deep-review\` for a dual general+adversarial pass.</sub>`,
+  );
+  process.stdout.write(lines.join("\n"));
+
+  // ---- Machine outputs for the workflow ----
+  if (env.GITHUB_OUTPUT) {
+    appendFileSync(env.GITHUB_OUTPUT, `verdict=${worst}\n`);
+    appendFileSync(
+      env.GITHUB_OUTPUT,
+      `summary=${total} findings: ${counts.critical} critical, ${counts.major} major, ${counts.minor} minor, ${counts.nit} nit\n`,
+    );
+  }
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Collapses the 3 per-repo copies of the AI reviewer into one canonical home here in `singi-labs/.github`, exposed as a `workflow_call` reusable workflow.

- `scripts/ai-review/` — the engine (`review.mjs`, now prompt-selectable via env) + backend & **frontend** prompt sets.
- `.github/workflows/ai-review-reusable.yml` — reusable workflow; checks out the caller repo + this repo, picks prompts by `profile` (backend/frontend), posts comment + blocking `AI Review` status.

Next: each repo (api/sdk = backend, web = frontend) switches to a 5-line caller and drops its local `scripts/ai-review/`. See `scripts/ai-review/README.md` for the caller snippet.