### PR TITLE
feat(engineering): shared engineering harness + reusable secret-scan gate

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,31 @@
+name: Secret scan (reusable)
+
+# Reusable org workflow: scans the checked-out tree for committed secrets and
+# fails the PR if any are found. Repos call it via templates/pr-gates.yml so the
+# scan is defined once and stays in sync everywhere.
+#
+# Uses the gitleaks OSS binary via its official container image (no paid action,
+# no license key). Scans working-tree files (--no-git) so existing history does
+# not produce noise — the gate is "no secret in the proposed file state".
+
+on:
+  workflow_call:
+    inputs:
+      gitleaks-version:
+        description: gitleaks container tag to pin
+        type: string
+        default: "v8.21.2"
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Scan for secrets
+        run: |
+          docker run --rm -v "${{ github.workspace }}:/repo" \
+            "ghcr.io/gitleaks/gitleaks:${{ inputs.gitleaks-version }}" \
+            detect --source=/repo --no-git --redact --no-banner --verbose --exit-code=1

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -14,7 +14,7 @@ on:
       gitleaks-version:
         description: gitleaks container tag to pin
         type: string
-        default: "v8.21.2"
+        default: "v8.30.1"
 
 jobs:
   gitleaks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,8 +62,10 @@ cd <repo>
 
 ## 5. Standards
 
-The full engineering standards are the source of truth (a maintainer will point
-you to them). The essentials the AI reviewer and maintainers enforce:
+How we engineer — the operating model, what the harness enforces, and what you
+inherit — is in [`engineering/harness.md`](engineering/harness.md). If you use a
+coding agent, drop [`engineering/agent-instructions.md`](engineering/agent-instructions.md)
+into your local clone. The essentials the AI reviewer and maintainers enforce:
 
 - **TypeScript strict** — no `any`, no `@ts-ignore`; `as` casts need a comment.
 - **Validate at every boundary** with Zod (inputs, env, AT Protocol records);

--- a/engineering/README.md
+++ b/engineering/README.md
@@ -1,0 +1,30 @@
+# Singi Labs — Engineering
+
+The shared engineering harness for every Singi Labs repo (Barazo + Sifa). One
+canonical home; product docs and per-repo files link here rather than copying, so
+nothing drifts.
+
+| Doc | What it's for |
+|---|---|
+| [`harness.md`](harness.md) | How we engineer with AI agents — the operating model, what the harness enforces, what you inherit vs. what's maintainer-only. Read this first. |
+| [`agent-instructions.md`](agent-instructions.md) | Drop-in `CLAUDE.md` / `AGENTS.md` for your local clone so your coding agent stays in bounds. |
+| [`templates/pr-gates.yml`](templates/pr-gates.yml) | Caller workflow a repo adds to run the shared secret scan on every PR. |
+
+See also, at the org root: [`CONTRIBUTING.md`](../CONTRIBUTING.md) ·
+[`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) · [`CLA.md`](../CLA.md) ·
+[`ARCHITECTURE.md`](../ARCHITECTURE.md)
+
+## The harness has two halves
+
+- **Prose** — the docs above and each repo's `AGENTS.md`. Tells you the rules.
+- **Executable** — git hooks, CI gates, secret scanning, branch protection, the
+  automated reviewer. *Enforces* the rules without depending on anyone remembering.
+
+The executable half is the one that holds. See `harness.md` for why.
+
+## Adding the shared secret scan to a repo
+
+Copy [`templates/pr-gates.yml`](templates/pr-gates.yml) to the repo as
+`.github/workflows/pr-gates.yml`. It calls the org's reusable
+[`secret-scan`](../.github/workflows/secret-scan.yml) workflow — change the scan
+once here and every repo that references it gets the update.

--- a/engineering/agent-instructions.md
+++ b/engineering/agent-instructions.md
@@ -1,0 +1,63 @@
+# Contributor agent instructions
+
+Generic instruction file for contributors using Claude Code or a similar coding
+agent. **Copy this into the root of your local clone** as `CLAUDE.md` (or
+`AGENTS.md`) so your agent stays within the house rules. It references no private
+Singi Labs context — safe to use anywhere.
+
+> Do not commit this file to the repo. If a maintainer `AGENTS.md` already exists
+> in the repo, that one wins for repo-specific detail — this file adds the
+> behavioural guardrails.
+
+## Project
+
+You are contributing to a **Singi Labs** repo — open foundations for networked apps
+on the AT Protocol. Products: **Barazo** (federated forum) and **Sifa**
+(professional identity). The repo's own `README.md` / `AGENTS.md` has the exact
+stack, package manager, and setup. General shape: TypeScript (strict), Node current
+LTS, npm or pnpm per repo, PostgreSQL + Drizzle and Valkey on the backends, Next.js
+/ React / Tailwind on the frontends.
+
+## Hard rules (never violate)
+
+- **Never push to `main`.** Branch (`feat/…`, `fix/…`) and open a PR.
+- **Never commit secrets** — no `.env`, keys, tokens, JWKS, or credentials. A secret
+  scan blocks the PR if you do.
+- **AT Protocol auth = OAuth only.** Never use app passwords in code.
+- **No AI attribution** in commit messages, PR titles/bodies, or comments. No
+  `Co-Authored-By`, no "Generated with…" lines. Write neutral messages.
+- **Conventional commits**: `type(scope): description` (`feat`, `fix`, `docs`,
+  `test`, `refactor`, `chore`, `ci`).
+
+## Engineering standards
+
+- TypeScript strict — no `any`, no `@ts-ignore`; an `as` cast needs a comment.
+- Write tests with the change; aim 80%+ coverage on new code.
+- Validate input with Zod at every boundary; derive types from the schema.
+- Sanitize user-generated output; rate-limit auth/write/expensive endpoints.
+- Accessibility (UI): semantic HTML, keyboard nav, WCAG 2.2 AA.
+- Use the project logger, not `console.*`.
+- UI: reuse existing `src/components/ui/` primitives and design tokens before
+  creating new ones.
+
+## Before claiming a task is done
+
+Run and confirm all pass — show the output, never assert "fixed"/"passing" without it:
+
+```bash
+npm test        # or the repo's test command
+npm run lint
+npm run typecheck
+```
+
+## Workflow
+
+1. Read the linked issue. Confirm scope before large changes.
+2. Branch from `main`, one feature per branch.
+3. Implement with tests. Keep diffs focused.
+4. Open a PR, `Closes #NN`, fill the checklist. An automated reviewer posts a
+   blocking check (address what it requests); a maintainer reviews before merge —
+   you cannot self-merge.
+
+See [`harness.md`](harness.md) for the full operating model and what the harness
+enforces.

--- a/engineering/harness.md
+++ b/engineering/harness.md
@@ -1,0 +1,132 @@
+# The Engineering Harness
+
+How Singi Labs builds software with AI agents: the shared operating model that
+surrounds every model, applied across **Barazo** and **Sifa**. This is the
+reference a contributor (or their coding agent) reads once to understand how we
+work and what keeps quality high.
+
+## Agent = Model + Harness
+
+A useful frame (after Google's *The New SDLC with Vibe Coding*, 2026): an agent is
+`Model + Harness`. The model is the reasoning engine, but most of the behaviour
+you actually experience comes from the **harness** — the instructions, tools,
+guardrails, feedback loops, and review gates wrapped around it. When an agent does
+something wrong, the cause is usually not the model; it is a missing rule, an
+absent guardrail, or a vague spec. So we invest in the harness, and we version it
+like code.
+
+The harness has **two halves**, and the second one is the one that actually holds:
+
+| Half | What it is | How it reaches you | What enforces it |
+|---|---|---|---|
+| **Instructions (prose)** | this doc, `AGENTS.md`, the standards, conventions | docs + the agent file in your clone | the agent reading it (fallible) |
+| **Guardrails (executable)** | git hooks, CI checks, secret scanning, branch protection, the automated reviewer | committed in the repo + org workflows + rulesets | runs whether or not anyone read the docs |
+
+Prose tells you the rules. The executable half enforces them deterministically, so
+correctness never depends on a human — or an agent — remembering. If you only read
+one section, read that distinction.
+
+## The operating model
+
+The developer's real output is not code; it is the system that produces and
+verifies code. Ours runs on the GitHub Project board, and the loop is:
+
+```
+human defines spec  →  contributor/agent implements  →  tests + automated review verify  →  human review
+   (acceptance                  (with tests)              (CI gates, AI reviewer)          (maintainer; squash merge)
+    criteria)                                                                                      │
+        ▲                                                                                          │
+        └─────────────────────────────  rework feedback loop  ◀──────────────────────────────────┘
+```
+
+- **Specs become acceptance criteria become tests.** A task is not ready to pick up
+  until it has clear acceptance criteria. Those criteria are what your tests assert.
+  Write tests *with* the implementation — the test suite is the contract, more
+  precise than any prose description.
+- **The bar is the gate, not the demo.** "It seems to work" is not the standard. A
+  green test suite, a passing automated review, and a maintainer's approval are.
+- **Humans set direction; agents and contributors implement; gates verify.** A
+  two-pass human review (a technical pass, then a user/mobile pass) is the final
+  judgment no automated check replaces.
+
+## The harness anatomy
+
+Every component below exists in our setup. Naming them gives each an owner and a home.
+
+| Component | What it is | Where it lives |
+|---|---|---|
+| **Instructions / rule files** | `AGENTS.md` per repo, the shared standards, this doc | repo roots (synced) + this directory |
+| **Tools** | package scripts, Docker services, the `gh` CLI | each repo's `package.json` / compose files |
+| **Sandboxes / execution** | local Docker services; CI runners; scoped contributor access (no production, no deploy secrets) | repos + CI + org team permissions |
+| **Orchestration** | the Project board (the "factory floor"); task decomposition; routing mechanical work to cheaper models | org project + maintainer tooling |
+| **Guardrails / hooks** | git hooks (lint-staged pre-commit, commit-message lint, pre-push lint+typecheck+build+test); CI checks | committed `.husky/` + CI |
+| **Verification** | the test suites; a blocking automated AI review check; CODEOWNERS + branch protection + maintainer review | repo tests, org workflows, rulesets |
+| **Observability** | error tracking, metrics, structured logs | production infrastructure (maintainer-operated) |
+
+## What you inherit vs. what is maintainer-only
+
+This boundary keeps the harness reproducible.
+
+**Shared — every contributor inherits this, human or agent:**
+
+- `AGENTS.md` in each repo (house rules, stack, conventions).
+- Committed git hooks: pre-commit, commit-message, pre-push.
+- CI gates: the blocking automated AI review, lint / typecheck / test / build, and
+  secret scanning.
+- Branch protection + CODEOWNERS — no self-merge; a maintainer reviews every PR.
+- The standards and this harness doc.
+- The contributor agent-instruction file ([`agent-instructions.md`](agent-instructions.md)),
+  copied into your local clone.
+
+**Maintainer-only — NOT inherited, NOT committed to product repos:**
+
+- Maintainer-local coding-agent hooks (worktree enforcement, secret-file blocks,
+  commit-message guards), personal workflow skills, and editor wiring.
+- Production access, deploy keys, and internal planning documents.
+
+> Do **not** adopt any `.claude/` directory you find committed in a repo — it
+> references maintainer-private context. Use only the contributor agent file above.
+
+## Guardrails currently enforced
+
+Deterministic — code, not "you were told":
+
+- **No self-merge / no push to `main`** — branch protection + CODEOWNERS.
+- **No secrets in the tree** — secret scanning runs on every PR (see
+  [`templates/pr-gates.yml`](templates/pr-gates.yml)); `.env` and keys are git-ignored.
+- **Conventional commits** — enforced by the commit-message hook.
+- **Green before merge** — pre-push runs lint + typecheck + build + test; CI repeats
+  them as the hard gate; the automated reviewer posts a blocking check; a maintainer
+  reviews.
+- **No AI attribution** in commits/PRs — write neutral messages; no `Co-Authored-By`
+  or "Generated with…" lines.
+- **AT Protocol auth is OAuth, never app passwords.**
+
+## How it stays in sync
+
+One canonical copy of each thing; everything else points at it.
+
+- **Org defaults** (CONTRIBUTING, code of conduct, CLA) live once in `singi-labs/.github`
+  and GitHub applies them to every repo automatically.
+- **This harness + standards** live once here; per-repo docs and the product docs
+  sites link to them rather than copying.
+- **`AGENTS.md`** is generated from a single source and synced into each repo by an
+  automated workflow — never hand-edit a repo's `AGENTS.md`; change the source.
+- **CI guardrails** are shared as reusable workflows: a repo references the org
+  workflow instead of duplicating it, so a change here reaches every repo.
+
+## Roadmap
+
+Explicit choices, not oversights:
+
+1. **Evals (not just tests) — only when a product ships an AI feature.** None today.
+   If a feature itself becomes an agent, it gets an eval suite with an explicit
+   rubric (task success, tool-use quality, trajectory, hallucination, response
+   quality), gated in CI the same way tests gate a service.
+2. **Agent-run observability** — metering the coding-agent loop (cost, first-pass
+   success), beyond the production observability we already run.
+3. **MCP / A2A open standards** — adopted only if cross-tool interoperability or
+   multi-agent delegation becomes a real need.
+
+---
+*Frame adapted from Google, "The New SDLC with Vibe Coding" (2026).*

--- a/engineering/templates/pr-gates.yml
+++ b/engineering/templates/pr-gates.yml
@@ -1,0 +1,17 @@
+# Copy this to a repo as: .github/workflows/pr-gates.yml
+#
+# Runs the org's shared, deterministic guardrails on every PR. Today that is the
+# secret scan; add more shared jobs here as the org workflow grows. Defined once
+# in singi-labs/.github — update there and every repo referencing it follows.
+
+name: PR Gates
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  secret-scan:
+    uses: singi-labs/.github/.github/workflows/secret-scan.yml@main


### PR DESCRIPTION
## What

Establishes `singi-labs/.github` as the canonical home for the shared engineering harness — the operating model every Barazo + Sifa contributor (human or coding agent) reads once.

**Prose layer** (`engineering/`):
- `harness.md` — operating model, harness anatomy, the **prose vs. executable** split (prose tells the rules; hooks/CI enforce them), and what contributors inherit vs. what stays maintainer-only.
- `agent-instructions.md` — drop-in `CLAUDE.md`/`AGENTS.md` for a contributor's local clone.
- `README.md` — index.

**Executable layer** (the half that actually holds):
- `.github/workflows/secret-scan.yml` — reusable gitleaks workflow (OSS container, no paid action / no license key). Scans the working tree, fails the PR on a committed secret.
- `engineering/templates/pr-gates.yml` — 12-line caller a repo drops in to run the shared scan. Defined once here; every repo that references it stays in sync.

`CONTRIBUTING.md` now points its Standards section at `engineering/`.

## Why

Today the harness/standards live in a private notes workspace — contributors can't read or review them, which defeats the point of a shared asset. This moves the shareable subset into the public org-defaults repo: one canonical copy, GitHub-native propagation, reviewable like code.

The secret scan is the first contributor-facing **deterministic** guardrail. Maintainer-local agent hooks (worktree enforcement, secret-file blocks, commit guards) do not travel to contributors — committed CI is what does.

## Follow-ups (not in this PR)
- Wire `pr-gates.yml` into each product repo (`sifa-api`, `sifa-web`, barazo-*).
- Migrate the full standards docs (backend/frontend/atproto/naming) from the private workspace after a per-doc secrets check.
- Keep the full, infra-detailed harness (hostnames, board mechanics, personal hooks) in the private `.internal` repo.
- Sifa product-setup half of onboarding → `sifa-docs` site (links back here).

## Notes
- `secret-scan.yml` pins gitleaks `v8.21.2`; bump via the workflow input.
- No changes to existing workflows or the AGENTS.md sync.