### PR TITLE
docs(engineering): publish shared engineering standards

### DIFF
--- a/engineering/README.md
+++ b/engineering/README.md
@@ -9,6 +9,22 @@ nothing drifts.
 | [`harness.md`](harness.md) | How we engineer with AI agents — the operating model, what the harness enforces, what you inherit vs. what's maintainer-only. Read this first. |
 | [`agent-instructions.md`](agent-instructions.md) | Drop-in `CLAUDE.md` / `AGENTS.md` for your local clone so your coding agent stays in bounds. |
 | [`templates/pr-gates.yml`](templates/pr-gates.yml) | Caller workflow a repo adds to run the shared secret scan on every PR. |
+| [`standards/`](standards/) | The engineering standards the AI reviewer and maintainers enforce (see below). |
+
+### Standards
+
+The single source of truth for our engineering conventions — referenced by every
+repo's `AGENTS.md` rather than copied:
+
+| Doc | Scope |
+|---|---|
+| [`standards/shared.md`](standards/shared.md) | Cross-cutting: testing, CI/CD, git workflow, dependencies |
+| [`standards/backend.md`](standards/backend.md) | Backend patterns, API conventions, data, security |
+| [`standards/frontend.md`](standards/frontend.md) | Frontend patterns, accessibility, components |
+| [`standards/atproto-conventions.md`](standards/atproto-conventions.md) | AT Protocol conventions |
+| [`standards/naming-lexicon.md`](standards/naming-lexicon.md) | Lexicon naming rules |
+| [`standards/quality-measures.md`](standards/quality-measures.md) | Quality, security & reliability overview |
+| [`standards/readme-template.md`](standards/readme-template.md) | README template for repos |
 
 See also, at the org root: [`CONTRIBUTING.md`](../CONTRIBUTING.md) ·
 [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) · [`CLA.md`](../CLA.md) ·

--- a/engineering/standards/atproto-conventions.md
+++ b/engineering/standards/atproto-conventions.md
@@ -1,0 +1,294 @@
+# AT Protocol Conventions for Barazo
+
+Condensed reference for AT Protocol compliance during lexicon design, API implementation, and code review. Derived from the [AT Protocol specification](https://atproto.com/specs/lexicon) and [data model](https://atproto.com/specs/data-model), verified against canonical Bluesky lexicons.
+
+**When to consult this file:** Before writing or reviewing any lexicon schema, firehose handler, PDS interaction, or record validation code.
+
+**When this file is insufficient:** For edge cases or protocol changes, check the source:
+- Spec: `https://atproto.com/specs/lexicon` and `https://atproto.com/specs/data-model`
+- Canonical lexicons: `https://github.com/bluesky-social/atproto/tree/main/lexicons`
+- Fetch a single raw file from GitHub for comparison (cheaper than Context7)
+
+---
+
+## 1. Lexicon JSON File Structure
+
+```json
+{
+  "lexicon": 1,
+  "id": "forum.barazo.topic.post",
+  "description": "Optional short overview.",
+  "defs": {
+    "main": { ... },
+    "namedDef": { ... }
+  }
+}
+```
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `lexicon` | Yes | Always `1` (current version) |
+| `id` | Yes | NSID matching the file path |
+| `description` | No | Short overview of the lexicon |
+| `defs` | Yes | Map of definition names to schema objects |
+
+- `main` is the primary definition, referenced by NSID alone
+- Other named defs are referenced as `forum.barazo.topic.post#namedDef`
+- Each def must have a `type` field
+
+---
+
+## 2. Primary Types
+
+### `record` (what Barazo uses for PDS-stored data)
+
+```json
+{
+  "type": "record",
+  "description": "Record containing a ...",
+  "key": "tid",
+  "record": {
+    "type": "object",
+    "required": ["field1", "field2"],
+    "properties": { ... }
+  }
+}
+```
+
+- `key` (string, required): Record key type -- see section 5
+- `record` (object, required): Must be type `object`
+
+### `query` -- XRPC GET endpoint
+### `procedure` -- XRPC POST endpoint
+### `subscription` -- WebSocket event stream
+
+Barazo uses `record` for lexicons. Query/procedure/subscription are for XRPC endpoints (defined in `com.atproto.*`, not in app lexicons).
+
+---
+
+## 3. Field Types
+
+### Primitives
+
+| Type | Key fields | Notes |
+|------|-----------|-------|
+| `string` | `format`, `maxLength`, `maxGraphemes`, `minLength`, `minGraphemes`, `enum`, `knownValues`, `default`, `const` | `maxLength` = UTF-8 bytes. `maxGraphemes` = Unicode Grapheme Clusters. |
+| `integer` | `minimum`, `maximum`, `enum`, `default`, `const` | Signed 64-bit, but limit to 53 bits for JS safety. |
+| `boolean` | `default`, `const` | |
+| `bytes` | `minLength`, `maxLength` | Raw byte count. JSON: `{"$bytes": "<base64>"}` |
+
+### Complex
+
+| Type | Key fields | Notes |
+|------|-----------|-------|
+| `object` | `properties`, `required`, `nullable` | Generic nested object. |
+| `array` | `items`, `minLength`, `maxLength` | `maxLength` = max element count. `items` = element schema. |
+| `blob` | `accept`, `maxSize` | `accept`: MIME types with `*` globs (e.g., `image/*`). `maxSize`: bytes. |
+| `cid-link` | (none) | Content identifier reference. JSON: `{"$link": "<cid>"}` |
+
+### References
+
+| Type | Key fields | Notes |
+|------|-----------|-------|
+| `ref` | `ref` (string, required) | Points to one specific definition. Cannot ref `token`, `ref`, or `union`. |
+| `union` | `refs` (array, required), `closed` (bool, optional) | Multiple possible types. Default `closed: false` (extensible). |
+| `token` | (none) | Named empty value. Can only be referenced in `knownValues`/`enum` strings. |
+| `unknown` | (none) | Any valid data model value. Use sparingly. |
+
+---
+
+## 4. String Formats
+
+Use `"format"` on string fields for semantic validation:
+
+| Format | Validates as | Example |
+|--------|-------------|---------|
+| `did` | Generic DID | `did:plc:abc123` |
+| `handle` | AT Protocol handle | `user.bsky.social` |
+| `at-uri` | AT URI | `at://did:plc:abc/app.bsky.feed.post/rkey` |
+| `at-identifier` | Handle OR DID | Either of the above |
+| `nsid` | Namespaced identifier | `app.bsky.feed.post` |
+| `cid` | Content identifier (string) | `bafyrei...` |
+| `tid` | Timestamp identifier | `3jzfcijpj2z2a` |
+| `record-key` | General record key syntax | See section 5 |
+| `datetime` | ISO 8601 with timezone | `2026-02-12T10:00:00.000Z` |
+| `uri` | Generic URI (RFC-3986) | `https://example.com` |
+| `language` | BCP 47 language tag | `en`, `nl`, `en-US` |
+
+---
+
+## 5. Record Key Types
+
+Specified in the lexicon `"key"` field:
+
+| Key type | When to use | Example |
+|----------|------------|---------|
+| `tid` | Most records. Timestamp-based, unique per collection. | `3jzfcijpj2z2a` |
+| `literal:self` | Singleton records (one per user). | Profile, preferences |
+| `nsid` | When key must be a valid NSID. | Rare |
+| `any` | Flexible. Domain names, integers, AT URIs. | Specialized cases |
+
+**Record key constraints (all types):**
+- Characters: `A-Za-z0-9` `.` `-` `_` `:` `~`
+- Length: 1-512 characters
+- Prohibited: `.` and `..` alone
+- Case-sensitive
+- Must be valid URI path components
+
+---
+
+## 6. The strongRef Pattern
+
+All record-to-record references use `com.atproto.repo.strongRef`:
+
+```json
+{
+  "type": "ref",
+  "ref": "com.atproto.repo.strongRef",
+  "description": "The thing being referenced."
+}
+```
+
+The strongRef object contains `{ uri, cid }` -- an AT URI plus a content hash. This is universal across the ecosystem (Bluesky, Frontpage, WhiteWind, all community apps).
+
+**When to use:** Any field that points to another record (parent, root, subject, target).
+
+**When NOT to use:** DID references (just use `"format": "did"` on a string), AT URI without integrity check (use `"format": "at-uri"` on a string).
+
+---
+
+## 7. Self-Labels Pattern
+
+Content warnings / maturity labels follow Bluesky's pattern:
+
+```json
+"labels": {
+  "type": "union",
+  "description": "Self-label values for content maturity.",
+  "refs": ["com.atproto.label.defs#selfLabels"]
+}
+```
+
+- Use `union` (not `ref`) for forward compatibility
+- The `selfLabels` type contains `{ values: [{ val: string }] }`, max 10 entries
+- Standard label values: `sexual`, `nudity`, `graphic-media`, `porn`
+
+---
+
+## 8. String Length Conventions
+
+Two independent constraints work together:
+
+| Constraint | Measures | Purpose |
+|-----------|---------|---------|
+| `maxLength` | UTF-8 bytes | Prevents storage overflow. Required for all strings with limits. |
+| `maxGraphemes` | Unicode Grapheme Clusters | Prevents UI overflow. Loosely = "visible characters". |
+
+**Ecosystem ratio:** ~10:1 (bytes to graphemes). Examples from Bluesky:
+- Display name: `maxGraphemes: 64`, `maxLength: 640`
+- Post text: `maxGraphemes: 300`, `maxLength: 3000`
+- Tags: `maxGraphemes: 64`, `maxLength: 640`
+
+**Barazo convention:**
+- Short text (titles, tags, names): specify both `maxGraphemes` and `maxLength`
+- Long-form content (post body, reply body): `maxLength` only (following WhiteWind)
+- `minLength` is always in UTF-8 bytes
+
+---
+
+## 9. Timestamps
+
+All `createdAt` fields are **client-declared**:
+- The description should say: `"Client-declared timestamp when this [thing] was originally created."`
+- AppViews must NOT trust these for ordering -- use server-side `indexedAt` instead
+- Format: `"format": "datetime"` (ISO 8601 with timezone)
+
+---
+
+## 10. Unknown Fields and Validation
+
+**Lenient by default:** Unexpected fields in records should be ignored (treated as warnings at worst). Third parties can add fields to records.
+
+**Three validation modes:**
+1. **Explicit validation** (`validate: true`): record fails if Lexicon unknown
+2. **No validation** (`validate: false`): records allowed without checks
+3. **Optimistic** (default): validates if Lexicon known locally, allows if unknown
+
+**Barazo policy:** Always validate with explicit mode for our own lexicons. Use Zod schemas from `@singi-labs/barazo-lexicons` at both API endpoints and firehose ingestion.
+
+---
+
+## 11. Data Model Rules
+
+- **No floats.** Integers only (signed 64-bit, 53-bit for JS safety).
+- **`$`-prefixed fields are reserved:** `$type`, `$bytes`, `$link`. Never define custom `$` fields.
+- **Null vs missing:** Semantically different. Omitting a field != setting it to `null` != setting it to a falsy value.
+- **Object keys** are always strings.
+- **CID format:** Version 1, SHA-256, base32 with `b` prefix.
+
+---
+
+## 12. Validation Tooling (CI Integration)
+
+### `@atproto/lex-cli` (primary)
+- Validates lexicon JSON against the AT Protocol meta-schema
+- Generates TypeScript types from lexicons
+- Installed as dev dependency in barazo-lexicons
+
+```bash
+# Validate schemas
+./node_modules/.bin/lex validate ./lexicons/**/*.json
+
+# Generate TypeScript
+./node_modules/.bin/lex gen-server ./src/lexicon ./lexicons/*
+```
+
+### `goat` CLI (supplementary linting)
+- Lints lexicon files for best practices (e.g., missing maxLength)
+- Can pull and compare against published lexicons
+
+```bash
+goat lex lint lexicons/forum/barazo/topic/post.json
+goat lex pull app.bsky.feed.post  # fetch canonical for comparison
+```
+
+### Bluesky interop tests
+- Repo: `github.com/bluesky-social/atproto-interop-tests`
+- Reusable test files for spec compliance
+- Reference for edge cases in TID generation, CID computation, handle resolution
+
+---
+
+## 13. Common Mistakes
+
+| Mistake | Correct approach |
+|---------|-----------------|
+| Inline `{ uri, cid }` instead of strongRef | Use `"ref": "com.atproto.repo.strongRef"` |
+| `"type": "ref"` for labels | Use `"type": "union", "refs": [...]` |
+| `maxLength` only (no `maxGraphemes`) on short text | Add both for Unicode safety |
+| `"key": "tid"` on singleton records | Use `"key": "literal:self"` |
+| Trusting `createdAt` for ordering | Use server-side `indexedAt` |
+| `$type` in lexicon properties | Omitted -- added automatically by protocol |
+| Defining custom `$`-prefixed fields | Reserved for protocol use |
+| Floats in record schemas | Use `integer` only |
+| Required field that should be optional | Adding required fields later is a breaking change |
+| `contentFormat: "markdown"` as required | Make optional with default if only one value exists |
+
+---
+
+## 14. Quick Reference: Barazo Lexicons
+
+| Record type | Key | Required fields |
+|------------|-----|----------------|
+| `forum.barazo.topic.post` | `tid` | title, content, community, category, createdAt |
+| `forum.barazo.topic.reply` | `tid` | content, root, parent, community, createdAt |
+| `forum.barazo.interaction.reaction` | `tid` | subject, type, community, createdAt |
+| `forum.barazo.interaction.vote` | `tid` | subject, direction, community, createdAt *(schema defined, not yet implemented in AppView)* |
+| `forum.barazo.actor.preferences` | `literal:self` | maturityLevel, updatedAt |
+
+**Canonical schemas:** `specs/prd-lexicons.md` section 4.
+
+---
+
+**Last verified against:** AT Protocol spec (atproto.com, February 2026)
+**Canonical spec URL:** https://atproto.com/specs/lexicon

--- a/engineering/standards/backend.md
+++ b/engineering/standards/backend.md
@@ -1,0 +1,316 @@
+# Barazo - Backend Engineering Standards
+
+**Created:** 2026-02-09
+**Status:** Active - enforce from first commit
+
+Standards specific to barazo-api (AppView backend). Read standards/shared.md first.
+
+---
+
+## Security Measures
+
+### Input Validation (Zod)
+- **Every API endpoint** validates input with Zod schemas
+- **Every firehose record** validated against lexicon schema before indexing
+- Reject malformed data early, log the rejection, don't process it
+- No raw string interpolation into SQL (use parameterized queries via Drizzle ORM)
+
+### Output Sanitization
+- **DOMPurify** for all user-generated HTML/markdown before rendering
+- Note: DOMPurify requires jsdom for server-side use. Plan for periodic jsdom window cleanup in long-running processes (AppView) to prevent memory accumulation. Do NOT use happy-dom with DOMPurify (known XSS vectors).
+- Sanitize AT Protocol display names and profile data before display
+- CSP headers to prevent inline script execution
+- **DOMPurify configuration (explicit):** use restrictive ALLOWED_TAGS and ALLOWED_ATTR lists (not permissive defaults). Strip all event handlers, `javascript:` URIs, `data:` URIs for non-image contexts.
+- **DOMPurify instance lifecycle:** singleton instance with shared jsdom window. Recreate window every 10,000 sanitizations or every hour (whichever comes first) to prevent memory accumulation.
+- **Sanitization order:** markdown -> HTML conversion FIRST, then DOMPurify sanitization on the HTML output (never sanitize raw markdown).
+- **Unicode normalization:** NFC normalize all text input before validation AND storage. Strip bidirectional override characters (U+202A-U+202E, U+2066-U+2069) and other control characters.
+
+### HTTP Security (Helmet)
+- Helmet middleware on all routes
+- Content-Security-Policy (strict, no inline scripts)
+- X-Content-Type-Options: nosniff
+- X-Frame-Options: DENY
+- Strict-Transport-Security (HSTS)
+- Referrer-Policy: strict-origin-when-cross-origin
+
+### Rate Limiting
+- Per-IP rate limiting on all API endpoints
+- Stricter limits on write endpoints (create topic, post reply)
+- Auth endpoint rate limiting (prevent brute force)
+- Firehose processing rate limiting (prevent resource exhaustion from spam records)
+- Per-DID rate limiting for authenticated requests (primary limiter, harder to bypass than per-IP)
+- **New account rate limiting:** Accounts with < 7 days of indexed activity in a community get stricter write limits (3 writes/min vs 10 for established accounts). "New" is per-community, not global. See `decisions/content-moderation.md` Bot & Spam Prevention Strategy.
+- Search endpoints: stricter limits (20 req/min unauthenticated, 60 req/min authenticated) separate from general API limits
+- Auth endpoints: 10 req/min per IP for `/api/auth/login`, 5 req/min for `/api/auth/callback`
+- Exponential backoff on repeated rate limit violations
+- Per-post mention limit: maximum 10 unique @mentions per topic/reply
+
+### Authentication & Authorization
+- AT Protocol OAuth with DPoP token binding (as per spec)
+- PKCE required on all OAuth flows (code_verifier + code_challenge with S256)
+- State parameter: cryptographically random (minimum 32 bytes), bound to Valkey session, 5-minute expiry
+- Role-based authorization for moderation actions
+- Verify DID ownership on every authenticated request:
+  - Resolve DID document (PLC directory or DNS) with caching (TTL: 1 hour)
+  - Fail closed: if DID resolution fails, reject the request (do not serve from stale cache beyond TTL)
+  - Monitor PLC audit log for key rotation events; invalidate cached DID documents on rotation
+- **Token persistence strategy (hybrid):**
+  - Refresh token: HTTP-only, Secure, SameSite=Strict cookie (never accessible to JavaScript)
+  - Access token: short-lived (15 minutes), held in memory only (React state/context)
+  - Token refresh: silent refresh via `/api/auth/refresh` using HTTP-only cookie
+  - Never store access tokens in localStorage or sessionStorage
+- Session management: Valkey-backed sessions, 7-day refresh token expiry (configurable)
+- CSRF: Bearer tokens in Authorization header are inherently CSRF-safe. The refresh endpoint (cookie-based) uses SameSite=Strict. If SameSite is insufficient for any future flow, add CSRF tokens.
+- Session invalidation: on account deletion (`DELETE /api/users/me` or firehose `#account` deletion), immediately delete ALL Valkey sessions for that DID
+
+### Data Deletion (Right to Erasure)
+- Process firehose deletion events per `specs/prd-api.md` Firehose Consumer section (`#commit` delete + `#account` deletion; do NOT implement deprecated `#tombstone`)
+- Provide direct deletion request mechanism (contact form / AT Protocol notification) independent of firehose
+- Delete from live/production systems immediately upon valid request
+- Backup data: apply deletions within 30 days (data "beyond use" pending natural expiration)
+- If backup is restored, re-apply all deletions that occurred since backup creation
+- Response to direct requests within one month (GDPR Art. 12(3))
+
+### Dependency Security
+- Dependabot enabled with weekly schedule (migrate to Renovate if moving off GitHub)
+- `pnpm audit` in CI pipeline (fail on high/critical vulnerabilities)
+- Lock file committed and integrity-checked
+- Minimal dependency footprint (prefer standard library where possible)
+
+### Secret Rotation
+- Document rotation procedures for every secret type: database passwords, Valkey password, OAuth client credentials, AI_ENCRYPTION_KEY, GlitchTip DSN
+- Zero-downtime rotation: accept both old and new credentials during rotation window
+- Managed hosting: automate rotation on a schedule (minimum quarterly)
+- Self-hosters: document manual rotation in security hardening guide
+- Monitor logs for credential exposure patterns (connection strings, API keys in Pino output)
+
+### CORS
+- Explicitly configured allowed origins (no wildcard `*` in production)
+- Credentials mode properly configured for OAuth flow
+
+### Age Requirements
+- Terms of Service require minimum age of 16 (Dutch UAVG GDPR threshold)
+- Age self-declaration on first attempt to access Mature content or post in Mature categories (not required for SFW posting)
+- See `decisions/legal.md` Children's Data & Age Verification section for full requirements
+- Implementation: `specs/prd-api.md` M10 age-declaration endpoint
+
+---
+
+## Fastify API Patterns
+
+### Response Schema Serialization
+
+Fastify uses `fast-json-stringify` to serialize responses. This **strips any field not declared in the response JSON schema**. This is a silent data loss issue -- your handler returns the right data, but the client never sees it.
+
+**Every error response schema must explicitly include:**
+```typescript
+const errorJsonSchema = {
+  type: "object" as const,
+  properties: {
+    error: { type: "string" as const },
+    message: { type: "string" as const },
+    statusCode: { type: "integer" as const },
+    // ... plus any domain-specific fields
+  },
+};
+```
+
+If you omit `message` or `statusCode`, the client receives `{}` even though Fastify's error handler sets those fields.
+
+### Nullable Fields in OpenAPI Schemas
+
+For fields that can be explicitly set to `null` (e.g., clearing a description, moving a category to root):
+
+- **Zod:** `.nullable().optional()` -- allows `null` (clear value), `undefined` (don't change), or the actual type
+- **OpenAPI/Fastify JSON schema:** `type: ["string", "null"]` (not just `type: "string"`)
+
+```typescript
+// Zod
+description: z.string().max(500).nullable().optional(),
+
+// Fastify route schema
+description: { type: ["string", "null"], maxLength: 500 },
+```
+
+### Gate Consistency Across Endpoint Variants
+
+When adding access control or filtering to a **list endpoint** (e.g., `GET /api/topics`), always check these related endpoints for the same gate:
+
+1. **Single-resource GET** (e.g., `GET /api/topics/:uri`) -- often overlooked, allows bypassing filters via direct URL
+2. **Write endpoints** (e.g., `POST /api/topics`) -- users shouldn't create resources they can't view
+3. **Nested resource endpoints** (e.g., `GET /api/topics/:uri/replies`) -- inherit parent's access rules
+
+This is especially critical for maturity filtering, community membership, and role-based access.
+
+---
+
+## Database Practices
+
+### PostgreSQL
+- All queries via Drizzle ORM (type-safe, parameterized)
+- Migrations tracked in version control (Drizzle Kit)
+- Indexes on all frequently queried columns
+- Connection pooling (pg-pool or Drizzle's built-in)
+- No raw SQL strings unless in migration files
+- **Multi-tenant query safety:** Every query against shared tables (topics, categories, replies, reactions) MUST include `communityDid` in the WHERE clause. This applies to counts, existence checks, and joins -- not just primary queries. Forgetting this causes cross-community data leakage in global aggregator mode.
+- **ID generation:** Use `crypto.randomUUID()` (Node.js built-in) for all server-generated identifiers (category IDs, session tokens, etc.). Never use `Math.random()` -- it is not cryptographically secure and produces predictable values. Format: `prefix-${randomUUID()}` (e.g., `cat-`, `rpt-`).
+- **Database role separation (mandatory):**
+  - `barazo_migrator` -- owns schema, runs DDL (used only by migration scripts via `MIGRATION_DATABASE_URL`)
+  - `barazo_app` -- INSERT/UPDATE/DELETE/SELECT on data tables (used by the API server via `DATABASE_URL`)
+  - `barazo_readonly` -- SELECT only (used for search, public read endpoints, reporting)
+  - Plugin database access: restricted role with explicit grants on plugin-specific tables only (PostgreSQL-level enforcement, not just application-level)
+  - Migrations run with `barazo_migrator` via separate `MIGRATION_DATABASE_URL`, never the application role
+- **Connection pooling configuration (explicit):**
+  - `max`: 20 (single-community), 50 (global aggregator)
+  - `idleTimeoutMillis`: 30000
+  - `connectionTimeoutMillis`: 5000
+- **Query safety:**
+  - `statement_timeout`: 30 seconds on `barazo_app` role (kills runaway queries)
+  - `idle_in_transaction_session_timeout`: 60 seconds
+  - Search queries: separate 5-second `statement_timeout` via `SET LOCAL` before vector/full-text queries
+- **PostgreSQL logging (production):**
+  - `log_statement = 'ddl'` (only log schema changes, not data queries with PII)
+  - `log_min_duration_statement = 1000` (log slow queries over 1 second)
+- **Indexes for security-sensitive operations:**
+  - `author_did` / `did` columns across all tables (required for GDPR deletion performance)
+  - `reporter_did` in reports table
+  - `community_did + status` in filter tables
+- **Audit logging:**
+  - `admin_audit_log` table: append-only (no UPDATE/DELETE for application role)
+  - Log all admin actions: settings changes, category CRUD, maturity changes, threshold changes, plugin install/enable/disable, global filter changes, user deletion requests
+  - Retain for GDPR accountability period
+
+### Valkey
+- **Authentication required:** configure `requirepass` in Valkey; connect via `redis://:${VALKEY_PASSWORD}@valkey:6379`
+- **Dangerous commands disabled:** rename `FLUSHALL`, `FLUSHDB`, `CONFIG`, `DEBUG`, `KEYS` via `rename-command` in Valkey config
+- **Memory policy:** `maxmemory-policy volatile-lru` (evict only keys with TTL set)
+- Used for caching and sessions (not as primary data store for content)
+- TTL on all cache entries (no unbounded cache growth)
+- **Cache key namespacing:** `barazo:{entity}:{id}` (e.g., `barazo:session:{token_hash}`, `barazo:reputation:{did}`, `barazo:summary:{topic_id}`)
+- **Multi-tenant (P3):** prefix all keys with `barazo:{community_id}:{entity}:{id}` to prevent cross-tenant cache leakage
+- Cache invalidation strategy documented per cached entity
+- Connection error handling (graceful degradation if Valkey is down)
+- Never cache raw Bearer tokens or OAuth refresh tokens. Cache only a hash or reference.
+- **TLS:** Required for managed hosting (P3). Optional but recommended for self-hosted production.
+
+### Encryption at Rest
+
+**Sensitive Data Classification:**
+The following data requires application-level encryption before storage:
+- BYOK API keys (AI providers: OpenAI, Anthropic, OpenRouter, etc.)
+- OAuth refresh tokens (stored in Valkey sessions)
+- Any future PII stored beyond AT Protocol public data
+
+**Encryption Standard:**
+- Algorithm: AES-256-GCM (authenticated encryption)
+- Key derivation: HKDF from master secret with per-community salt
+- Master secret: environment variable (`AI_ENCRYPTION_KEY`), never stored in database
+- Per-community data encryption key (DEK): generated per community, encrypted with master key (KEK), stored in database
+- Memory handling: zero sensitive values from memory after use
+
+**Key Rotation:**
+- Master key rotation: re-encrypt all DEKs with new master key (no re-encryption of data needed)
+- DEK rotation: re-encrypt all data encrypted with old DEK
+- Document rotation procedure in operations runbook
+- Log key access events (not values) for breach detection
+
+**Disk Encryption:**
+- Managed hosting: rely on Hetzner's disk encryption
+- Self-hosters: recommend LUKS full-disk encryption in security hardening guide
+- Backups: encrypt with GPG or `age` before storing off-server (see `prd-deploy.md` backup section)
+
+---
+
+## Error Monitoring & Observability
+
+### GlitchTip (self-hosted)
+- Self-hosted on Hetzner infrastructure (Sentry SDK-compatible, same `@sentry/node` client, different DSN)
+- Integrate from first deployment
+- Capture all unhandled exceptions and rejections
+- Performance monitoring for API endpoint latency
+- Source maps uploaded during build
+- Environment separation (development, staging, production)
+- Alert on new error types
+- No third-party data transfer -- all error data stays on our infrastructure
+
+### Structured Logging (Pino)
+- Pino logger (native Fastify integration)
+- JSON structured logs in production
+- Pretty-print in development
+- Log levels: error, warn, info, debug
+- Request ID correlation across log entries
+- No sensitive data in logs (no tokens, no PII)
+
+### Health Checks
+- `/health` endpoint: basic liveness (is the server running?)
+- `/health/ready` endpoint: readiness (database connected, Valkey connected, firehose subscribed)
+- Used by Docker HEALTHCHECK and load balancer
+
+---
+
+## Monitoring & Alerting
+
+### Metrics to Track
+- API response times (p50, p95, p99)
+- Error rates by endpoint
+- Firehose processing lag (time between record creation and indexing)
+- Database query latency
+- Cache hit/miss ratio
+- Active WebSocket connections (for future real-time features, P5+)
+
+### Alerts (via GlitchTip for P1-2, Grafana + Prometheus from P3)
+- Error rate spike (> 5% of requests)
+- API latency spike (p95 > 2s)
+- Firehose subscription disconnect
+- Database connection failures
+- Disk/memory threshold warnings
+
+### Data Breach Response
+
+Breach notification procedures and timelines defined in `decisions/legal.md` Data Breach Notification section. Implementation requirements:
+
+- Breach detection and severity classification built into monitoring (GlitchTip alerts)
+- Breach notification templates prepared and tested before launch
+- Breach notification timeline specified in DPA with managed hosting customers
+- Breach log maintained per GDPR Art. 33(5)
+
+---
+
+## Analytics (P3)
+
+### Umami (self-hosted)
+- Privacy-first web analytics for the marketing site and public-facing pages
+- Self-hosted on Hetzner (no third-party data transfer)
+- No cookies, no fingerprinting, no visitor profiling
+- GDPR compliant by design -- no consent banner needed
+
+### PostHog (self-hosted, P3)
+- Track admin actions and business metrics ONLY
+- Self-hosted on Hetzner (all data stays on our infrastructure)
+- NO end-user tracking on the forum (no cookies, no pixels, no fingerprinting)
+- Forum usage stats (posts, users, activity) come from the AppView database, not analytics
+- Respect Do Not Track headers
+- GDPR compliant by design
+
+### What we track (admin/business only)
+- Admin dashboard feature usage
+- Onboarding funnel (forum setup flow)
+- Billing conversion metrics
+- MRR, churn, growth
+
+### What we never track
+- Forum end-user browsing behavior
+- User reading patterns
+- Personal identification of forum visitors
+- Any data that would conflict with "no tracking, no ads" principle
+
+---
+
+## References
+
+- Fastify Security: https://fastify.dev/docs/latest/Guides/Recommendations/
+- GlitchTip: https://glitchtip.com/documentation (uses Sentry SDK: https://docs.sentry.io/platforms/javascript/guides/node/)
+- Drizzle ORM: https://orm.drizzle.team/
+- PostHog: https://posthog.com/docs/self-host
+- Stripe Billing: https://stripe.com/docs/billing
+- Valkey: https://valkey.io/

--- a/engineering/standards/frontend.md
+++ b/engineering/standards/frontend.md
@@ -1,0 +1,385 @@
+# Barazo - Frontend Engineering Standards
+
+**Created:** 2026-02-09
+**Status:** Active - enforce from first commit
+
+Standards specific to barazo-web (forum frontend). Read standards/shared.md first.
+
+---
+
+## Frontend Standards
+
+### shadcn/ui
+- Used for admin dashboard, settings, billing pages
+- Components copied into project (no npm dependency lock-in)
+- Follows Tailwind design system
+- Built on Radix UI Primitives (ARIA attributes, keyboard navigation, focus management handled automatically)
+- Developers must still provide: labels, color contrast verification, meaningful alt text
+
+### Design System: Colors
+
+Barazo uses **Radix Colors** as the structural color system with **Flexoki** accent colors for visual identity.
+
+- Use Radix Colors' 12-step semantic scales for all UI chrome: backgrounds, surfaces, borders, text, focus rings, interactive states
+- Seed Radix custom palette with Flexoki accent hues to generate the full scale
+- Light/dark mode via Radix's `.light` / `.dark` class toggle, respecting `prefers-color-scheme`
+- All custom color usage must reference design tokens (CSS variables), never raw hex values
+- Verify contrast ratios against WCAG 2.2 AA: 4.5:1 for normal text, 3:1 for large text and UI components
+
+**Active accent palette (5 colors from Flexoki):**
+
+| Role | CSS variable | Light | Dark | Use for |
+|------|-------------|-------|------|---------|
+| Primary | `--accent-primary` | `#24837B` | `#3AA99F` | Links, primary buttons, active nav, focus rings |
+| Info | `--accent-info` | `#5E409D` | `#8B7EC8` | Notification badges, tips, informational callouts |
+| Success | `--accent-success` | `#66800B` | `#879A39` | Confirmations, solved markers, online status |
+| Warning | `--accent-warning` | `#BC5215` | `#DA702C` | Pending moderation, limits, flagged content |
+| Error | `--accent-error` | `#AF3029` | `#D14D41` | Validation errors, destructive actions, reports |
+
+- Yellow, blue, and magenta are **not** in the active palette. Do not use them for UI elements.
+- The extended Flexoki scale remains available for non-UI uses (syntax highlighting, data visualization) if needed.
+- Each accent must be defined as a Radix 12-step scale (generated via Radix custom palette tool) for hover, active, border, and solid variants.
+
+**References:** Radix Colors (https://www.radix-ui.com/colors), Flexoki (https://stephango.com/flexoki)
+
+### Design System: Icons
+
+Barazo uses **Phosphor Icons** as the sole icon library (replacing shadcn/ui's default Lucide).
+
+- Package: `@phosphor-icons/react` (tree-shakeable, only imported icons affect bundle)
+- Default weight: `regular` | Default size: `24px`
+- Weight usage convention:
+  - `thin` -- decorative, background, low-emphasis
+  - `light` -- secondary actions, metadata
+  - `regular` -- standard UI (buttons, navigation, form elements)
+  - `bold` -- emphasis, primary actions, active states
+  - `fill` -- selected/active state indicators
+  - `duotone` -- feature highlights, onboarding, empty states
+- Create a project `<Icon>` wrapper component that enforces default size/weight and accepts overrides
+- When adapting shadcn/ui components, replace all Lucide imports with Phosphor equivalents
+- No mixing with other icon libraries -- Phosphor only
+
+**Reference:** Phosphor Icons (https://phosphoricons.com)
+
+### Design System: Typography
+
+Barazo uses the **Source** font family, self-hosted via `next/font` (zero external DNS calls).
+
+| Role | Font | Usage |
+|------|------|-------|
+| UI + body | Source Sans 3 | All interface text, post body, headings, navigation |
+| Monospace | Source Code Pro | Code blocks, inline code, technical content |
+| Serif (optional) | Source Serif 4 | Available in system but not used by default |
+
+- Load via `next/font/local` or `next/font/google` (both download at build time, serve from own domain)
+- Font weights to load: 400 (regular), 600 (semibold), 700 (bold). Do not load extra weights.
+- Set `font-display: swap` for all faces (handled automatically by `next/font`)
+- Define as CSS custom properties: `--font-sans`, `--font-mono`, `--font-serif`
+- Apply `--font-sans` to `<body>`, `--font-mono` to `<code>`, `<pre>`, `<kbd>` elements
+- Never reference font names directly in components -- always use the CSS variables
+
+**References:** Source Sans 3 (https://github.com/adobe-fonts/source-sans), Source Code Pro (https://github.com/adobe-fonts/source-code-pro)
+
+### Design System: Syntax Highlighting
+
+Code blocks in forum posts are highlighted with **Shiki** using the **Flexoki** theme, server-side rendered.
+
+- Package: `shiki` (MIT)
+- Render code blocks on the server -- no client-side JS for highlighting
+- Use Flexoki dark theme when `.dark` is active, Flexoki light theme when `.light` is active
+- Dual theme rendering: Shiki outputs both themes' styles in a single pass, CSS toggles visibility
+- Markdown code fences (` ```language `) trigger highlighting; inline code (single backticks) gets background tint only
+- Support all major languages at minimum: JavaScript, TypeScript, Python, Rust, Go, HTML, CSS, JSON, YAML, Bash, SQL, Markdown
+- Line numbers: off by default, opt-in via ` ```language showLineNumbers `
+- Copy-to-clipboard button on all code blocks (top-right corner, Phosphor `Copy` icon)
+
+**References:** Shiki (https://shiki.style), Flexoki theme (https://github.com/kepano/flexoki)
+
+### Forum UI
+- Custom components for forum-specific patterns (topic lists, thread views, editors)
+- Forum components follow Radix-style composable primitive patterns (same ARIA rigor as shadcn/ui)
+- Consistent with shadcn/ui design tokens but purpose-built for forum UX
+- Mobile-first responsive design (see Mobile-First Development below)
+- Keyboard navigation support on all interactive elements
+
+### Mobile-First Development
+
+Mobile is the primary viewport. Desktop is the enhancement.
+
+**Development discipline:**
+- Build and visually verify every component at 375px width first, then scale up to tablet (768px) and desktop (1440px)
+- Tailwind utilities without a breakpoint prefix define the mobile layout. Use `md:` and `lg:` prefixes to adapt upward. Never design desktop-first and then "fix mobile later."
+- If a component looks broken at 375px, that's the bug. If it looks broken at 1440px, that's also a bug -- but mobile gets fixed first.
+
+**Tailwind lint enforcement:**
+- `eslint-plugin-tailwindcss` in the ESLint config to catch class ordering issues and invalid utilities
+- No automated rule can fully enforce "mobile-first thinking," but the plugin catches structural Tailwind mistakes that correlate with responsive issues
+
+**QA review:**
+- Review all UI changes at 375px, 768px, and 1440px viewports (Responsively App or equivalent multi-viewport tool)
+- Mobile viewport (375px) is the primary review target -- check it first
+
+---
+
+## Rendering Strategy: Server Components First
+
+Every component is a React Server Component by default. Client Components (`"use client"`) are the exception, used only when genuinely required. This mirrors Astro's islands architecture: the page is static HTML with zero client JS, except for explicitly interactive elements.
+
+### Rules
+
+1. **Server Components are the default.** Do not add `"use client"` unless the component genuinely needs it.
+2. **Push `"use client"` boundaries as deep as possible.** If a page needs one interactive element, only that element is a Client Component -- not the page, not the section, not the wrapper.
+3. **Never mark layout or page components as Client Components.** `app/layout.tsx` and `app/*/page.tsx` must always be Server Components. Interactive parts go in separate Client Component leaf files.
+4. **Every `"use client"` directive requires a comment explaining why.** Enforced in PR review.
+
+### Valid reasons for `"use client"`
+
+- Uses `useState`, `useReducer`, `useEffect`, `useRef` with DOM manipulation
+- Attaches event handlers (`onClick`, `onChange`, `onSubmit`, etc.)
+- Uses browser-only APIs (`localStorage`, `window`, `IntersectionObserver`)
+- Uses React context that reads/writes client state
+- Uses third-party libraries that require browser environment
+
+### NOT valid reasons for `"use client"`
+
+- Importing a Client Component (importing from a Server Component is fine -- the import creates the boundary automatically)
+- Using `async/await` (Server Components support this natively)
+- Fetching data (Server Components fetch directly from database/API/cache)
+- Reading cookies or headers (use `next/headers`)
+- Conditional rendering based on server-side data
+
+### Expected Client Components
+
+Maintain an explicit list of Client Components and their justification. Any new `"use client"` directive in a PR must be reviewed against this list -- if it's not here, it needs discussion.
+
+| Component | Reason |
+|-----------|--------|
+| ReactionButton | `onClick`, `useState` for optimistic update |
+| ReplyEditor | Browser textarea API, `useState`, event handlers |
+| ThemeToggle | `localStorage`, `useState` |
+| NotificationBadge | Real-time updates, `useState` |
+| SearchCombobox | Keyboard events, `useState`, focus management |
+| CommandPalette (cmdk) | Keyboard events, `useState`, portal |
+| InfiniteScrollLoader | `IntersectionObserver` (opt-in only, never default) |
+| TopicSortDropdown | `useState`, event handlers |
+| ModerationActions | `onClick`, confirmation dialogs |
+| CopyCodeButton | `navigator.clipboard` API |
+
+This list will grow as features ship, but growth should be gradual and justified. If it exceeds ~30 entries, audit whether any can be consolidated or pushed back to server.
+
+### Client JS Budget (per route, gzipped, excluding shared React runtime)
+
+| Route | Budget |
+|-------|--------|
+| Topic listing (category/homepage) | 40KB |
+| Topic thread view | 50KB |
+| User profile | 30KB |
+| Admin panel | 80KB |
+| Auth/login | 20KB |
+
+The React runtime (~85KB gzipped) is shared across all routes via the framework chunk. This is the cost of using Next.js -- it's justified by the forum's genuine interactivity needs. Everything above that baseline must earn its place.
+
+### Streaming SSR
+
+Use Next.js streaming with `<Suspense>` boundaries for progressive page delivery:
+
+- **Shell** (nav, sidebar, footer) renders immediately as static Server Components
+- **Main content** streams as data resolves from database/API
+- **Skeleton components** as `<Suspense>` fallbacks (matching final layout, not spinners)
+- **Below-fold content** (e.g., replies beyond the initial viewport) deferred with separate `<Suspense>` boundaries
+- **Non-critical UI** (related topics sidebar, user badges) in their own `<Suspense>` boundaries so they don't block the main content stream
+
+### Data Fetching Pattern
+
+- **Server Components** fetch data directly (database queries via Drizzle, API calls, Valkey cache reads) -- no client-side fetch for initial page render
+- **React Query** (`@tanstack/react-query`) used only in Client Components for: mutations, optimistic updates, polling for real-time data, and cache invalidation after user actions
+- **Server Actions** for form submissions (works with and without JS -- progressive enhancement)
+- **No `useEffect` for data loading.** If a component needs data on mount, it should be a Server Component or receive data as props from a Server Component parent.
+
+### Component File Convention
+
+```
+src/components/
+  topic-card.tsx              # Server Component (no directive needed)
+  topic-card-actions.tsx      # "use client" -- reactions, bookmark, share
+  reply-editor.tsx            # "use client" -- textarea, formatting toolbar
+  category-header.tsx         # Server Component
+  notification-badge.tsx      # "use client" -- real-time count
+```
+
+Server Components have no directive. Client Components start with `"use client"` on line 1 followed by a comment explaining why. Separate files enforce the boundary -- never mix server and client logic in one file.
+
+### Skills
+
+Two Claude Code skills enforce this strategy:
+
+- **`barazo-component`** -- invoke when creating new components. Guides RSC-first structure and determines whether `"use client"` is needed.
+- **`barazo-bundle-audit`** -- invoke to audit existing code for unnecessary client JS, misplaced `"use client"` boundaries, and bundle budget compliance.
+
+---
+
+### UX Architecture (see decisions/ux-architecture.md for full strategy)
+
+**Every feature must meet these UX standards:**
+
+1. **Time to Value < 60 seconds** — from landing page to first post created
+2. **90%+ Completion Rate** — track signup, first post, first reply funnels
+3. **Keyboard-first navigation** — every action has a shortcut (documented via `?` help)
+4. **Loading states** — skeleton screens (not spinners), match final layout
+5. **Empty states** — helpful prompts with call-to-action ("No topics yet — create the first one!")
+6. **Error states** — specific fix instructions ("Topic title too short (min 3 chars)"), never generic
+7. **Progressive enhancement** — core functionality works without JavaScript
+8. **Undo for destructive actions** — soft deletes with 30-second undo window
+9. **Micro-interactions** — immediate feedback (button ripple, optimistic updates, toast notifications)
+10. **Mobile-first** — design for 375px width, scale up to desktop
+
+**Built-in patterns (use from day 1):**
+- Form validation: Zod schemas with user-friendly errors (client + server)
+- Command palette: Cmd+K search for topics, categories, actions (cmdk library)
+- Keyboard shortcuts: c (create), r (reply), j/k (navigate), Esc (close modals), / (search)
+- Smart defaults: 80/20 rule (works for 80%, experts can customize)
+
+**Quality gates (CI/CD):**
+- Lighthouse score ≥90 (all categories)
+- Signup completion rate ≥90% (PostHog funnel)
+- Keyboard-only walkthrough passes (manual testing before release)
+- WCAG 2.2 AA compliance (eslint-plugin-jsx-a11y strict + vitest-axe + @axe-core/playwright)
+
+---
+
+## SEO & Indexability
+
+Follow the SEO decisions in `decisions/frontend.md` and implement per the milestones in `specs/prd-web.md`.
+
+### Content maturity indexing rules
+
+Per `decisions/frontend.md` "SEO and Content Maturity":
+
+- **SFW pages:** full SEO (meta tags, JSON-LD, sitemaps, OG tags). No special treatment.
+- **Mature pages:** add `<meta name="rating" content="mature">`. Include in sitemaps. Include JSON-LD. OG image must fall back to community default (no user-uploaded images).
+- **Adult pages:** add `<meta name="robots" content="noindex, nofollow">`. Exclude from all sitemaps. Omit JSON-LD. Omit OG tags.
+- **Maturity inheritance:** category maturity inherits from community default. Post maturity inherits from category. Individual ratings can be higher but not lower than parent.
+- **Global aggregator:** SSR must render the age gate component (not content) for Mature pages when the request has no authenticated session. This ensures crawlers see the gate, not the content.
+
+### Key coding standards
+- Use `generateMetadata` per page type (Next.js App Router)
+- All URLs must be absolute in canonical and OpenGraph tags
+- JSON-LD preferred over Microdata (Google-recommended)
+- Test structured data with Google Rich Results Test in CI
+- Default OG image: 1200x630 with forum branding (fallback when no image in topic)
+- Dynamically generate robots.txt via Next.js `app/robots.ts`
+- See `decisions/frontend.md` for URL structure, robots.txt rules, blocked bots, sitemap structure, and structured data types
+
+---
+
+## Accessibility (WCAG 2.2 AA)
+
+### Target: WCAG 2.2 Level AA + selective AAA
+
+Barazo must be accessible from the first commit. This is both a legal requirement (European Accessibility Act, enforceable since June 2025) and a competitive advantage (Discourse has well-documented, persistent accessibility failures).
+
+### Semantic HTML (foundation)
+- Proper landmarks on every page: `<header>`, `<nav>`, `<main>`, `<footer>`
+- Heading hierarchy: `<h1>` page title, `<h2>` topic title, `<h3>` individual replies
+- `<article>` for each reply with `aria-labelledby`
+- `<button>` for actions, `<a>` for navigation (never `<div>` with click handlers)
+- `<nav aria-label="...">` for all navigation regions
+- Breadcrumbs with `<nav aria-label="Breadcrumb">` and `aria-current="page"`
+
+### Keyboard Navigation
+- Every feature usable without a mouse
+- Visible focus indicators using Tailwind `focus-visible:ring-*` (TailwindCSS resets remove default outlines)
+- Skip links: "Skip to main content" + "Skip to reply editor" (first child of body, visible on focus)
+- Custom `useFocusOnNavigate` hook to move focus after client-side route changes (Next.js does NOT handle this)
+- Escape key dismisses all overlays, popovers, and hover cards
+- Tab enters/exits editor toolbar, Arrow keys navigate within (roving tabindex)
+
+### Content Loading
+- **Pagination by default** for topic lists and thread views
+- Infinite scroll only as opt-in enhancement (never default)
+- New content announced via `aria-live="polite"` status messages
+
+### Dynamic Content & Notifications
+- `role="status"` with `aria-live="polite"` for non-critical updates ("3 new replies")
+- `role="alert"` with `aria-live="assertive"` only for errors
+- `role="log"` for thread/reply streams
+- Live region containers must exist in DOM at page load (not dynamically created)
+- Batch notifications instead of per-item announcements
+- Dedicated notifications page as alternative to real-time popups
+
+### Interactive Elements
+- Every button and control has an accessible name (`aria-label` or visible text)
+- Reaction buttons: `aria-pressed` for toggle state, `aria-label` includes count
+- Minimum target size: 24x24 CSS px (WCAG 2.2 AA), prefer 44x44 (AAA)
+- Profile hover cards: keyboard-triggerable, Escape-dismissible (SC 1.4.13)
+- Search: WAI-ARIA Combobox pattern with result count announcement
+
+### Form Fields
+- Every form field must use `<FormLabel>` from `@/components/ui/form-label`
+- Every field gets either the `required` or `optional` prop -- no unmarked fields
+- Asterisks render with `<span aria-hidden="true">` (screen readers use the HTML `required` attribute instead)
+- Required inputs must have the HTML `required` attribute
+- `<fieldset>/<legend>` groups: add `<span aria-hidden="true" className="ml-1 text-destructive">*</span>` inline to `<legend>` text, not via `FormLabel`
+- Checkbox labels: pass `block={false}` to `FormLabel`
+- Description/hint text stays as separate `<p>` elements below the label (not absorbed into `FormLabel`)
+
+### Theme Mode (Dark / Light)
+- **Dark mode is the default.** Light mode available via toggle.
+- Toggle control in main navigation bar (Phosphor `Moon` / `Sun` icon)
+- Initial state: respect `prefers-color-scheme` for first-time visitors; fall back to dark if no OS preference
+- Persist choice in `localStorage` (anonymous) or user preference record (authenticated)
+- Apply `.dark` / `.light` class on `<html>` element (Radix Colors convention)
+- Prevent FOUC: inline `<script>` in `<head>` reads preference before React hydration
+- All components must be tested in both modes -- never hardcode colors outside design tokens
+- Logo: render dark variant in dark mode, light variant in light mode (swap via CSS or conditional import)
+- Applies to both the forum frontend (barazo-web) and the marketing website (barazo.forum)
+
+### Color & Visual
+- Contrast ratios: 4.5:1 for normal text, 3:1 for large text and UI components
+- No information conveyed by color alone (always include text/icon alternative)
+- Respect `prefers-reduced-motion` media query
+- Respect `prefers-color-scheme` for initial theme mode (see Theme Mode section above)
+
+### Editor
+- Markdown textarea with fixed toolbar above (not floating)
+- WAI-ARIA Toolbar pattern for formatting buttons
+- Keyboard shortcuts for common formatting (Ctrl+B, Ctrl+I, etc.) with visible documentation
+- Escape key to exit textarea and move to next focusable element
+- Preview pane separate from editing area
+
+### Accessibility Testing (CI/CD)
+
+**Every PR (Tier 1):**
+- `eslint-plugin-jsx-a11y` in **strict** mode (not default "recommended")
+- `vitest-axe` for component-level tests (requires JSDOM, not Happy DOM)
+- `@axe-core/playwright` for page-level tests against rendered pages
+
+**Nightly (Tier 2):**
+- `pa11y-ci` crawling all page types against staging
+- Lighthouse CI with minimum accessibility score of 95
+
+**Before release (Tier 3 - manual):**
+- VoiceOver + Safari testing
+- Full keyboard-only navigation walkthrough
+- axe DevTools browser extension review
+
+**Note:** Automated tools catch only 30-50% of accessibility issues. Manual testing with assistive technology is required for every release.
+
+### Legal Compliance
+- Accessibility statement published at launch
+- Feedback mechanism (contact form) for reporting accessibility barriers
+- VPAT / Accessibility Conformance Report documenting conformance level
+- Self-hosted documentation includes guidance on maintaining accessibility
+
+---
+
+## References
+
+- shadcn/ui: https://ui.shadcn.com/
+- WCAG 2.2: https://www.w3.org/TR/WCAG22/
+- WAI-ARIA Authoring Practices: https://www.w3.org/WAI/ARIA/apg/
+- European Accessibility Act: https://accessible-eu-centre.ec.europa.eu/
+- axe-core: https://www.deque.com/axe/axe-core/
+- Radix UI Accessibility: https://www.radix-ui.com/primitives/docs/overview/accessibility
+- Google Structured Data (Forums): https://developers.google.com/search/docs/appearance/structured-data/discussion-forum
+- Schema.org DiscussionForumPosting: https://schema.org/DiscussionForumPosting

--- a/engineering/standards/naming-lexicon.md
+++ b/engineering/standards/naming-lexicon.md
@@ -1,0 +1,65 @@
+# Naming Lexicon
+
+Internal terminology for Barazo and Sifa. Use these terms in all docs, diagrams, specs, and conversations to eliminate ambiguity.
+
+**Rule: Never use "Barazo" or "Sifa" alone.** Always qualify which entity you mean.
+
+**Status:** Active
+**Created:** 2026-03-05
+
+---
+
+## Entities
+
+### Barazo
+
+| Term | Definition |
+|---|---|
+| **Barazo Inc** | The company. The people, the business, the decision-maker. |
+| **Barazo SaaS** | The hosted forum service at barazo.forum, run by Barazo Inc. |
+| **Barazo software** | The open-source codebase: barazo-api, barazo-web, barazo-deploy. |
+| **Barazo instance** | One running deployment of Barazo software. Use when the hosting model (SaaS or self-hosted) is irrelevant. |
+| **Barazo Discover** | The cross-community discovery surface. A Barazo instance without a community DID filter, sorted by popularity. Runs on a subdomain of barazo.forum. |
+
+### Sifa
+
+| Term | Definition |
+|---|---|
+| **Sifa Inc** | The company behind sifa.id. Separate entity from Barazo Inc, same owner. |
+| **Sifa app** | The product at sifa.id. Professional profiles, feed, and endorsements. |
+
+### Shared
+
+| Term | Definition |
+|---|---|
+| **AT Protocol user** | Any person identified by a DID, regardless of which AT Protocol app they use. |
+
+---
+
+## Roles
+
+| Term | Definition |
+|---|---|
+| **member** | A person who posts, replies, or votes in a Barazo forum. Identified by their DID. |
+| **operator** | A person who runs a self-hosted Barazo instance. Responsible for the server. |
+| **SaaS subscriber** | A person who pays Barazo Inc for hosted forums. |
+| **community admin** | A person who administrates a specific community: categories, settings, branding. |
+| **moderator** | A person who moderates content within a community. |
+| **Barazo Inc team** | Barazo Inc employees or contributors. |
+| **profile holder** | A person who has a professional profile on Sifa app. |
+| **Sifa client** | A person or organization that pays Sifa Inc. Business model TBD. |
+| **Sifa Inc team** | Sifa Inc employees or contributors. |
+
+---
+
+## Overlap Rules
+
+One person can hold multiple roles simultaneously. A single DID might belong to a member of three forums, a profile holder on Sifa app, and a SaaS subscriber. The terms stack; they do not conflict.
+
+When writing about a person, use the role relevant to the context. A SaaS subscriber who posts in their own forum is a "SaaS subscriber" in billing discussions and a "member" in content discussions.
+
+---
+
+## Scope
+
+This lexicon covers internal usage: workspace docs, CLAUDE.md files, decision docs, diagrams, specs, and conversations with AI agents. Public-facing copy (marketing site, docs site, README files) may use simplified terms, but the internal terms remain the source of truth.

--- a/engineering/standards/quality-measures.md
+++ b/engineering/standards/quality-measures.md
@@ -1,0 +1,313 @@
+# Quality, Security & Reliability Measures
+
+**Applies to:** All Singi Labs products (Barazo, Sifa)
+**Purpose:** Comprehensive overview of every measure in place to keep code quality, security, and reliability high. Useful as reference for blog posts, investor conversations, and onboarding.
+
+---
+
+## 1. Code Quality
+
+### Strict TypeScript
+- `strict: true` with additional flags: `noUncheckedIndexedAccess`, `noImplicitReturns`, `noFallthroughCasesInSwitch`, `noUnusedLocals`, `noUnusedParameters`, `exactOptionalPropertyTypes`
+- No `any` type (use `unknown` + narrowing)
+- No `@ts-ignore` or `@ts-expect-error`
+- No type assertions (`as`) without a comment explaining why
+
+### Linting
+- ESLint with `@typescript-eslint/strict-type-checked`
+- Zero warnings policy (warnings = errors in CI)
+- `eslint-plugin-jsx-a11y` in strict mode for accessibility
+- `eslint-plugin-tailwindcss` for CSS class ordering
+- No `console.log` in production code (enforced by lint rule)
+
+### Formatting
+- Prettier with single config, no overrides
+- Run on save and enforced in CI
+- Consistent across all repos (tab width: 2, single quotes, trailing commas)
+
+### Code Style
+- Named exports over default exports
+- Small components (max ~150 lines, then split)
+- No inline styles (all styling via Tailwind utility classes)
+- Server Components by default; `"use client"` requires justification comment
+- AT Protocol interactions through dedicated service layer (never direct from components)
+- Error boundaries on all network-dependent UI
+
+---
+
+## 2. Testing
+
+### Test-Driven Development (TDD)
+- Write tests BEFORE implementation code (Red -> Green -> Refactor)
+- Enforced via dedicated `test-driven-development` skill
+- No PR merges with failing tests
+
+### Unit Tests (Vitest)
+- All business logic has unit tests
+- Test files co-located with source (`foo.ts` -> `foo.test.ts`)
+- Target: 80%+ code coverage
+- Mock external dependencies (AT Protocol SDK, database, Valkey)
+
+### Integration Tests (Vitest + Supertest)
+- All API endpoints have integration tests
+- Test against real PostgreSQL + Valkey (Docker)
+- Test authentication flows (OAuth, DPoP)
+- Test firehose record processing (valid, malformed, edge cases)
+
+### Accessibility Tests (3 tiers)
+- **Tier 1 (every PR):** `eslint-plugin-jsx-a11y` strict + `vitest-axe` component tests + `@axe-core/playwright` page tests
+- **Tier 2 (nightly):** `pa11y-ci` crawling all page types + Lighthouse CI (min a11y score: 95)
+- **Tier 3 (before release):** Manual VoiceOver + Safari testing, keyboard-only walkthrough
+
+### Mobile Tests (nightly)
+- Playwright test suite at 375px viewport against staging
+- Horizontal overflow check on every page type
+- Auto-creates GitHub issue on failure with screenshots
+
+### Federation Tests
+- Test PDS instances via Docker Compose
+- Cross-instance posting and record resolution
+- Firehose subscription resilience (disconnect/reconnect, cursor replay)
+
+---
+
+## 3. Security
+
+### Input Validation
+- Every API endpoint validates input with Zod schemas
+- Every firehose record validated against lexicon schema before indexing
+- Environment variables validated with Zod at startup (fail fast)
+- Unicode NFC normalization on all text input; strip bidirectional override characters
+
+### Output Sanitization
+- DOMPurify on all user-generated HTML/markdown (restrictive ALLOWED_TAGS/ALLOWED_ATTR)
+- Sanitization order: markdown -> HTML conversion first, then DOMPurify
+- Server-side only (jsdom, NOT happy-dom — known XSS vectors)
+- AT Protocol display names and profile data sanitized before display
+
+### HTTP Security Headers (Helmet)
+- Content-Security-Policy (strict, no inline scripts)
+- X-Content-Type-Options: nosniff
+- X-Frame-Options: DENY
+- Strict-Transport-Security (HSTS)
+- Referrer-Policy: strict-origin-when-cross-origin
+
+### Rate Limiting
+- Per-IP rate limiting on all API endpoints
+- Per-DID rate limiting for authenticated requests (harder to bypass than IP)
+- Stricter limits on write endpoints, auth endpoints, and search
+- New account rate limiting (< 7 days activity = stricter write limits)
+- Per-post mention limit (max 10 unique @mentions)
+- Exponential backoff on repeated violations
+
+### Authentication & Authorization
+- AT Protocol OAuth with DPoP token binding
+- PKCE required on all OAuth flows (S256)
+- Cryptographically random state parameter (min 32 bytes, 5-minute expiry)
+- Refresh token: HTTP-only, Secure, SameSite=Strict cookie
+- Access token: short-lived (15 minutes), memory-only (never localStorage)
+- DID ownership verified on every authenticated request
+- Role-based authorization for moderation actions
+
+### Database Security
+- No raw SQL — Drizzle ORM with parameterized queries only
+- Database role separation: `migrator` (DDL), `app` (DML), `readonly` (SELECT)
+- `statement_timeout` on app role (30s general, 5s for search queries)
+- `idle_in_transaction_session_timeout`: 60 seconds
+- Audit log table: append-only (no UPDATE/DELETE for app role)
+- Multi-tenant query safety: every query includes `communityDid` in WHERE clause
+
+### Encryption
+- AES-256-GCM for sensitive data at rest (BYOK API keys, OAuth refresh tokens)
+- HKDF key derivation with per-community salt
+- Master key in environment variable, never in database
+- Documented key rotation procedures (zero-downtime)
+
+### Valkey (Cache) Security
+- Authentication required (`requirepass`)
+- Dangerous commands disabled (`FLUSHALL`, `FLUSHDB`, `CONFIG`, `DEBUG`, `KEYS`)
+- Memory policy: `volatile-lru` (evict only keys with TTL)
+- Never cache raw Bearer tokens (hash or reference only)
+- TLS required for managed hosting
+
+### CORS
+- Explicitly configured allowed origins (no wildcard `*` in production)
+- Credentials mode properly configured for OAuth flow
+
+### Dependency Security
+- Dependabot enabled with weekly schedule on all repos
+- `pnpm audit` in CI pipeline (fail on high/critical)
+- Lock file committed and integrity-checked
+- Monthly manual dependency review (`pnpm outdated -r`)
+
+### Secret Management
+- `.env` in `.gitignore` (never committed), `.env.example` committed
+- Documented rotation procedures for every secret type
+- Zero-downtime rotation: accept old + new credentials during rotation window
+- Monitor logs for credential exposure patterns
+
+---
+
+## 4. Git Workflow & Branch Protection
+
+### Branch Protection (GitHub)
+- Main branch protected: no direct commits
+- All changes via Pull Requests
+- CI checks must pass before merge
+- Conventional commit format enforced
+
+### Branch Protection (Local)
+- Pre-commit hook blocks commits on `main` in all repos
+- Enforced via husky (committed, shared) or `.git/hooks/` (local)
+
+### Conventional Commits
+- Format: `type(scope): description`
+- Enforced via commitlint + husky commit-msg hook
+- Validated in CI via GitHub Actions
+
+### Pre-push Validation
+- Pre-push hook runs `lint && typecheck && build && test` before allowing push
+- Catches CI failures locally before they reach GitHub Actions
+
+### Worktree Isolation (Multi-Session Safety)
+- Every feature branch gets its own git worktree
+- Never reuse an existing worktree from another session
+- Check for uncommitted changes before creating a worktree
+- One branch = one feature (no mixed changes)
+
+### PR Process
+- Self-review before opening (read own diff on GitHub)
+- Keep PRs focused and small (< 400 lines, one feature/fix per PR)
+- Wait for CI to pass before requesting review
+- Squash and merge (default)
+- Delete branch after merge
+
+---
+
+## 5. CI/CD (GitHub Actions)
+
+### On Every Pull Request
+1. Lint (ESLint strict, zero warnings)
+2. Type check (`tsc --noEmit`, strict mode)
+3. Unit tests (Vitest with coverage report)
+4. Integration tests (against Docker PostgreSQL + Valkey)
+5. Accessibility tests (`@axe-core/playwright`)
+6. Build verification (production build succeeds)
+7. Security scan (CodeQL)
+
+### On Merge to Main
+1. All PR checks pass
+2. Docker image build and push (GitHub Container Registry)
+3. Deployment to staging
+
+### Nightly
+1. Accessibility audit (`pa11y-ci` crawling all page types)
+2. Lighthouse CI (performance + accessibility, min a11y: 95)
+3. Mobile viewport tests (375px Playwright suite)
+4. Horizontal overflow check (all page types at 375px)
+5. Auto-creates GitHub issue on failure
+
+### Weekly
+1. Dependabot automated dependency update PRs
+2. Full security audit (`pnpm audit` + CodeQL)
+
+---
+
+## 6. Monitoring & Observability
+
+### Error Monitoring (GlitchTip)
+- Self-hosted (Sentry SDK-compatible, all data on own infrastructure)
+- Captures unhandled exceptions and rejections
+- Performance monitoring for API endpoint latency
+- Source maps uploaded during build
+- Environment separation (dev, staging, production)
+- Alerts on new error types
+
+### Structured Logging (Pino)
+- JSON structured logs in production
+- Request ID correlation across log entries
+- No sensitive data in logs (no tokens, no PII)
+- Log levels: error, warn, info, debug
+
+### Health Checks
+- `/health`: basic liveness (server running)
+- `/health/ready`: readiness (database, Valkey, firehose connected)
+- Used by Docker HEALTHCHECK and load balancer
+- Returns version info for deployment verification
+
+### Alerting
+- Error rate spike (> 5% of requests)
+- API latency spike (p95 > 2s)
+- Firehose subscription disconnect
+- Database connection failures
+- Disk/memory threshold warnings
+
+---
+
+## 7. Accessibility (WCAG 2.2 AA)
+
+- Semantic HTML with proper landmarks on every page
+- Heading hierarchy enforced
+- Keyboard navigation on all interactive elements
+- Visible focus indicators (Tailwind `focus-visible:ring-*`)
+- Skip links ("Skip to main content")
+- Minimum target size: 24x24 CSS px (AA), prefer 44x44 (AAA)
+- `aria-live` regions for dynamic content
+- Pagination by default (infinite scroll opt-in only)
+- Dark/light mode with `prefers-color-scheme` respect
+- Contrast ratios: 4.5:1 normal text, 3:1 large text
+- `prefers-reduced-motion` respected
+- Accessibility statement published at launch
+
+---
+
+## 8. SEO
+
+- JSON-LD structured data (Schema.org types per page)
+- OpenGraph + Twitter Card meta tags
+- Dynamic sitemaps via Next.js
+- Canonical URLs on all pages
+- `robots.txt` with AI crawler blocking
+- Server-side rendering for all public content
+- Content maturity affects indexing (Adult pages: `noindex, nofollow`)
+
+---
+
+## 9. Privacy & Data Protection
+
+- No tracking, no ads, no profiling
+- No third-party analytics (self-hosted Umami for marketing site only)
+- All infrastructure EU-based (Hetzner, Germany/Finland)
+- Data stored on user's PDS (AT Protocol — user owns their data)
+- GDPR-compliant data deletion (firehose deletion events + direct request mechanism)
+- Backup deletions applied within 30 days
+- Age requirement: 16+ (Dutch UAVG threshold)
+- Encryption at rest for sensitive data
+- No cookies for forum end-users (token in memory)
+
+---
+
+## 10. Infrastructure & Deployment
+
+- Hosting: Hetzner VPS (EU) + Bunny.net CDN (Slovenia)
+- Reverse proxy: Caddy (automatic TLS)
+- Deployment: Docker Compose
+- Database: PostgreSQL with connection pooling, role separation, statement timeouts
+- Cache: Valkey with authentication, dangerous commands disabled
+- Docker image tagging: semver (pinned in production, `latest` in staging)
+- Rollback: change Docker tag, `docker compose up -d`
+
+---
+
+## 11. Documentation & Process
+
+- Architecture Decision Records (ADRs) for significant technical decisions
+- Auto-generated API docs from Fastify routes + Zod schemas (OpenAPI 3.0)
+- Staleness detection: CI flags PRs that change API code without updating docs
+- READMEs follow shared template across all repos
+- Conventional commit messages auto-generate changelogs
+
+---
+
+**Created:** 2026-03-14
+**Sources:** `standards/shared.md`, `standards/backend.md`, `standards/frontend.md`, product CLAUDE.md files

--- a/engineering/standards/readme-template.md
+++ b/engineering/standards/readme-template.md
@@ -1,0 +1,141 @@
+# README Template for Barazo Repositories
+
+All Barazo repos (`barazo-api`, `barazo-web`, `barazo-lexicons`, `barazo-deploy`, `barazo-website`, `barazo-docs`) follow this template. When updating any README, use this as the reference. When changing the template itself, update ALL repo READMEs to match.
+
+## Conventions
+
+1. **Logo**: All repos use the theme-aware `<picture>` element. Never omit it.
+2. **Badges**: Standard set in this order: Status, License, CI (if workflow exists), Node.js (code repos), TypeScript (code repos). Use shields.io format.
+3. **Section separators**: `---` between every major section.
+4. **Related Repositories**: Always a table. Exclude the current repo from the list.
+5. **Community**: Always present, identical across repos (except issues link).
+6. **License**: Bold license name + link to LICENSE file. No rationale or justification -- that belongs in decision docs, not public READMEs.
+7. **Copyright**: `(c) 2026 Barazo` at the bottom of every README.
+8. **Section order**: Follow the ordering below exactly. Omit sections that don't apply (e.g., no "Tech Stack" for deploy). Never reorder.
+9. **Headings**: Use `##` for all sections. No `###` at the top level.
+10. **Tables**: Prefer tables over bullet lists for structured data (tech stack, features, routes).
+
+## Template
+
+```markdown
+<div align="center">
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/barazo-forum/.github/main/assets/logo-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/barazo-forum/.github/main/assets/logo-light.svg">
+  <img alt="Barazo Logo" src="https://raw.githubusercontent.com/barazo-forum/.github/main/assets/logo-dark.svg" width="120">
+</picture>
+
+# {Repo Name}
+
+**{One-line tagline. Consistent across docs.}**
+
+[![Status: Alpha](https://img.shields.io/badge/status-alpha-orange)]()
+[![License: {LICENSE}]({badge_url})]({license_url})
+[![CI]({ci_badge_url})]({ci_actions_url})
+[![Node.js](https://img.shields.io/badge/node-24%20LTS-brightgreen)](https://nodejs.org/)
+[![TypeScript](https://img.shields.io/badge/typescript-5.x-blue)](https://www.typescriptlang.org/)
+
+</div>
+
+---
+
+## Overview
+
+{2-4 sentences: what this repo is, what role it plays in the Barazo ecosystem,
+and who the audience is (developers, admins, self-hosters, etc.)}
+
+---
+
+## {Repo-specific sections}
+
+{Content unique to this repo: tech stack, features, API routes, schemas,
+deployment modes, etc. Use tables for structured data. Keep sections
+focused and scannable.}
+
+---
+
+## Quick Start
+
+{Clone, install, configure, run. Keep it copy-pasteable. Include
+prerequisites inline rather than as a separate section.}
+
+---
+
+## Development
+
+{Test/lint/build commands as a code block. Link to CONTRIBUTING.md.
+List 3-5 key standards as bullet points.}
+
+---
+
+## Related Repositories
+
+{Table format. Exclude the current repo.}
+
+| Repository | Description | License |
+|------------|-------------|---------|
+| ... | ... | ... |
+
+---
+
+## Community
+
+- **Website:** [{product-domain}]({product-url})
+- **Bluesky:** [@{product-bsky-handle}](https://bsky.app/profile/{product-bsky-handle})
+- **Issues:** [Report bugs](https://github.com/singi-labs/{repo}/issues)
+
+---
+
+## License
+
+**{License Name}** -- {One sentence: why this license.}
+
+See [LICENSE](LICENSE) for full terms.
+
+---
+
+(c) 2026 Barazo
+```
+
+## Badge Reference
+
+| Badge | Markdown | When to include |
+|-------|----------|-----------------|
+| Status | `[![Status: Alpha](https://img.shields.io/badge/status-alpha-orange)]()` | Always |
+| AGPL-3.0 | `[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL%203.0-blue.svg)](https://opensource.org/licenses/AGPL-3.0)` | barazo-api only |
+| MIT | `[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)` | All other repos |
+| CI | `[![CI](https://github.com/singi-labs/{repo}/actions/workflows/ci.yml/badge.svg)](https://github.com/singi-labs/{repo}/actions/workflows/ci.yml)` | Repos with CI workflow |
+| Node.js | `[![Node.js](https://img.shields.io/badge/node-24%20LTS-brightgreen)](https://nodejs.org/)` | Code repos (api, web, lexicons) |
+| TypeScript | `[![TypeScript](https://img.shields.io/badge/typescript-5.x-blue)](https://www.typescriptlang.org/)` | Code repos (api, web, lexicons) |
+
+## Section Order
+
+Mandatory sections (all repos):
+
+1. Header (logo, name, tagline, badges)
+2. Overview
+3. Quick Start
+4. Development
+5. Related Repositories
+6. Community
+7. License
+
+Optional sections (between Overview and Quick Start, repo-specific):
+
+- Tech Stack
+- Features / Implemented Features
+- Route Modules, Database Schema, etc.
+- Planned Features
+- API Documentation
+- Deployment modes, scripts, environment variables
+- Schemas, package exports, installation
+
+## Updating
+
+When this template changes:
+
+1. Update this file
+2. Regenerate all 6 repo READMEs to match
+3. Commit template change to workspace
+4. Create PRs for each repo README

--- a/engineering/standards/shared.md
+++ b/engineering/standards/shared.md
@@ -1,0 +1,984 @@
+# Barazo - Shared Engineering Standards
+
+**Created:** 2026-02-09
+**Status:** Active - enforce from first commit
+
+Standards that apply to ALL repos (barazo-api, barazo-web, barazo-lexicons, barazo-deploy). These are non-negotiable.
+
+---
+
+## Testing Strategy
+
+### Unit Tests (Vitest)
+- All business logic must have unit tests
+- Test files co-located with source: `foo.ts` -> `foo.test.ts`
+- Use `describe`/`it` blocks with descriptive names
+- Mock external dependencies (AT Protocol SDK, database, Valkey)
+- Target: **80%+ code coverage** from day one
+
+### Integration Tests (Vitest + Supertest)
+- All API endpoints must have integration tests
+- Test against a real PostgreSQL instance (Docker, test container)
+- Test authentication flows (OAuth, DPoP token validation)
+- Test moderation authorization (role-based access)
+- Test firehose record processing (valid records, malformed records, edge cases)
+
+### Federation Tests (Custom Harness)
+- Spin up test PDS instances via Docker Compose
+- Test cross-instance posting and record resolution
+- Test firehose subscription resilience (disconnect/reconnect, cursor replay)
+- Test data portability scenarios (PDS migration)
+- See: `research/06-skills-and-tooling.md` -> `federation-test-harness`
+
+### Test-Driven Development
+- Write tests BEFORE implementation code
+- Use the `test-driven-development` skill for every feature
+- Red -> Green -> Refactor cycle
+- No PR merges with failing tests
+
+### Test Infrastructure Patterns
+- **Extract shared mock helpers early.** Route tests share significant mock boilerplate (mock DB, chainable query builders, request factories). Extract to `tests/helpers/` as soon as two test files need the same pattern. Deduplication prevents mock drift across test files.
+- **Mock chain ordering matters.** Drizzle query mocks using `mockResolvedValueOnce` are consumed sequentially. When a new query is added to a route handler (e.g., a maturity check before the main query), all existing tests break because the mocks are consumed in the wrong order. When adding queries to handlers, audit all tests for that handler's mock sequence.
+- **Single source of truth for types.** Derive shared types (e.g., `MaturityRating`) from the Zod schema, then re-export. Don't maintain parallel type definitions -- they will diverge when someone adds a new enum value. Pattern: define in Zod validation file, re-export via utility module.
+- **Use partial mocks (`importOriginal`) for large modules.** When mocking a module that exports many functions (e.g., an API client), don't replace the entire module with only the functions your test needs. Use `vi.mock('@/lib/api/client', async (importOriginal) => ({ ...(await importOriginal()), yourMock: vi.fn() }))` to preserve all original exports and override only what you need. Full-replacement mocks silently break when other PRs add new exports that downstream components depend on.
+
+---
+
+## CI/CD (GitHub Actions)
+
+### On Every Pull Request
+1. **Lint** - ESLint with strict config (zero warnings allowed), including `eslint-plugin-jsx-a11y` in strict mode
+2. **Type Check** - `tsc --noEmit` (strict TypeScript, no errors)
+3. **Unit Tests** - Vitest with coverage report (includes vitest-axe accessibility tests)
+4. **Integration Tests** - Against Docker PostgreSQL + Valkey
+5. **Accessibility Tests** - @axe-core/playwright against rendered pages
+6. **Build** - Verify production build succeeds
+7. **Security Scan** - CodeQL for code vulnerabilities
+
+### On Merge to Main
+1. All PR checks pass
+2. Docker image build and push (GitHub Container Registry)
+3. Deployment to staging environment
+
+### Scheduled (Nightly)
+1. **Accessibility Audit** - pa11y-ci crawling all page types against staging
+2. **Lighthouse CI** - Performance + accessibility scores (minimum a11y score: 95). Must run with mobile emulation (Lighthouse's default -- do not override to desktop).
+3. **Mobile Viewport Tests** - Playwright test suite runs against staging at 375px viewport (in addition to desktop runs on PR). Covers all page types.
+4. **Horizontal Overflow Check** - Dedicated Playwright test that loads every page type at 375px and asserts `document.documentElement.scrollWidth <= document.documentElement.clientWidth`. Catches the most common mobile layout bug.
+5. **On nightly failure** - GitHub Actions workflow auto-creates an issue in barazo-workspace with failure details, screenshots, viewport size, and page URL. Labels: `bug`, `repo:web`, `mobile`.
+
+### Scheduled (Weekly)
+1. **Dependabot** - Automated dependency update PRs for all update types including majors. See "Dependency Management" section for full policy.
+2. **Full security audit** - `pnpm audit` + CodeQL + Snyk (if added)
+
+---
+
+## Code Quality Standards
+
+### TypeScript Configuration
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": true
+  }
+}
+```
+- **No `any` type** - use `unknown` if the type is truly unknown, then narrow
+- **No `@ts-ignore`** - fix the type error instead
+- **No type assertions (`as`)** unless with a comment explaining why
+
+### ESLint
+- Extend: `@typescript-eslint/strict-type-checked`
+- Zero warnings policy (warnings = errors in CI)
+- No `console.log` in production code (use Pino logger)
+- Enforce consistent import ordering
+
+### Prettier
+- Single config, no overrides
+- Run on save and in CI
+- Tab width: 2, single quotes, trailing commas
+
+### Conventional Commits
+- Enforced via commitlint + husky pre-commit hook
+- Format: `type(scope): description`
+- Types: feat, fix, docs, test, refactor, chore, ci
+- Scope: appview, frontend, lexicon, deploy, etc.
+- **Body (optional but recommended):** Explain the "why" behind the change
+- **Footer:** Reference issues (`Closes #123`) or breaking changes (`BREAKING CHANGE: ...`)
+
+**Examples:**
+```
+feat(appview): add firehose subscription with cursor persistence
+
+Implements Tap-based subscription to Bluesky relay, filtering for
+forum.barazo.* records. Cursor is persisted to PostgreSQL to survive
+restarts and avoid duplicate processing.
+
+Closes #42
+```
+
+```
+fix(frontend): sanitize markdown output to prevent XSS
+
+DOMPurify now runs on all user-generated markdown before rendering.
+This prevents script injection via malicious markdown syntax.
+
+Fixes #87
+```
+
+```
+test(appview): add integration tests for topic creation API
+
+Tests cover: valid creation, invalid input, auth failures,
+and PDS write errors.
+```
+
+**Breaking changes:**
+```
+feat(api)!: change topic list endpoint response format
+
+BREAKING CHANGE: GET /api/topics now returns paginated response
+with { data: [], cursor: string } instead of flat array.
+
+Migration guide: https://docs.barazo.forum/migration/v2
+```
+
+**Tools:**
+- `commitlint` enforces format on commit
+- `husky` runs commitlint as pre-commit hook
+- GitHub Actions validates on PR
+
+---
+
+## Git Workflow & Contribution Process
+
+### Branch Protection Rules
+
+**Main branch (`main`) is protected:**
+- No direct commits (even for solo development)
+- All changes via Pull Requests
+- CI checks must pass before merge
+- At least 1 approval required (can self-approve when solo, but review your own PR)
+- Conventional commit format enforced
+
+**Why protect `main` even when solo?**
+- Forces you to review your own changes (catch mistakes)
+- CI runs on every PR (catch breaking changes before merge)
+- Keeps commit history clean and linear
+- Makes it easy for future contributors (process already established)
+- GitHub Actions triggers work correctly (on PR vs on push to main)
+
+### Branching Strategy
+
+**Branch naming convention:**
+```
+<type>/<short-description>
+
+Examples:
+feat/firehose-subscription
+fix/xss-sanitization
+docs/api-reference
+test/topic-crud
+refactor/auth-middleware
+chore/update-deps
+```
+
+**Types match conventional commits:** feat, fix, docs, test, refactor, chore, ci
+
+**Branch lifecycle:**
+```
+Create branch → Make changes → Commit → Push → Open PR → Review → Merge → Delete branch
+```
+
+**Create branch from latest main:**
+```bash
+git checkout main
+git pull origin main
+git checkout -b feat/add-reactions
+```
+
+**Alternative: Use git worktrees** (recommended for larger features)
+```bash
+# From CLAUDE.md Git workflow section:
+# Substantial work -> create git worktree
+
+git worktree add ../barazo-api-reactions -b feat/add-reactions
+cd ../barazo-api-reactions
+# Work here, completely isolated from main
+```
+
+**Worktree branch reconciliation — never copy files manually:**
+- Worktrees branch from `main` at a point in time. If other PRs merge while you work, your worktree's branch diverges from current `main`.
+- **Before creating a PR**, rebase the worktree branch onto latest `main`: `git fetch origin main && git rebase origin/main`. This surfaces conflicts cleanly through git's merge machinery.
+- **Never manually copy files** between a worktree and another branch to work around CI or merge issues. Manual copying bypasses conflict detection and silently drops changes from the target branch (e.g., new functions added by other PRs). Always use `git merge` or `git rebase` to reconcile diverged branches.
+- If the worktree's branch is broken beyond repair (e.g., CI won't trigger), create a new branch from current `main` and **cherry-pick or rebase** the worktree commits onto it — don't copy files.
+
+### Pull Request Process
+
+**1. Create meaningful PR title and description**
+
+Use the PR template (see below). Every PR should answer:
+- **What** changed?
+- **Why** did it change?
+- **How** was it tested?
+- **Any** breaking changes or migrations?
+
+**2. Self-review before opening PR**
+
+- Read your own diff on GitHub (fresh eyes catch issues)
+- Run full test suite locally (`pnpm test`)
+- Check CI passes (lint, typecheck, tests, security scan)
+- Verify acceptance criteria met (if applicable)
+
+**3. Keep PRs focused and small**
+
+- One feature/fix per PR (easier to review)
+- Aim for < 400 lines changed (large PRs are hard to review)
+- If it's getting large, consider splitting into multiple PRs
+
+**4. Update documentation in same PR**
+
+- If you change API endpoints, update OpenAPI spec
+- If you add features, update README or docs/
+- If you change behavior, update relevant PRD or decision doc
+
+**5. Respond to CI failures immediately**
+
+- If CI fails, fix it before requesting review
+- Don't merge with failing tests (even if "it works locally")
+
+**6. Merge strategy**
+
+- **Squash and merge** (default, keeps main history clean)
+- Use for most PRs - collapses all commits into one
+- Final commit message = PR title + description
+
+- **Rebase and merge** (for clean commit history)
+- Use when PR commits are already well-structured
+- Preserves individual commits
+
+- **Merge commit** (avoid)
+- Creates noisy history, only use for coordinated releases
+
+### PR Template
+
+Create `.github/PULL_REQUEST_TEMPLATE.md` in each repo:
+
+```markdown
+## Description
+
+<!-- What does this PR do? Why is it needed? -->
+
+Closes #<!-- issue number -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactor (no functional changes)
+- [ ] Dependency update
+
+## Testing
+
+<!-- How was this tested? -->
+
+- [ ] Unit tests added/updated
+- [ ] Integration tests added/updated
+- [ ] Manual testing performed
+- [ ] Accessibility tested (if UI changes)
+- [ ] All tests pass locally
+
+## Checklist
+
+- [ ] Code follows conventional commit format
+- [ ] Self-review completed (read own diff)
+- [ ] No TypeScript errors or ESLint warnings
+- [ ] Documentation updated (if applicable)
+- [ ] Database migration included (if schema changed)
+- [ ] Breaking changes documented (if applicable)
+- [ ] CI checks pass
+
+## Screenshots/Logs (if applicable)
+
+<!-- Add screenshots for UI changes, or logs for backend changes -->
+```
+
+### Solo Development Best Practices
+
+**Even when working alone:**
+
+1. **Always use PRs** - Don't commit directly to `main`
+2. **Write meaningful PR descriptions** - Future you will thank you
+3. **Review your own PRs** - Catch mistakes before merging
+4. **Wait for CI to pass** - Don't merge on red
+5. **Delete branches after merge** - Keep repo clean
+
+**Fast workflow for small changes:**
+```bash
+# Fix a typo in docs
+git checkout -b docs/fix-typo
+# Make change
+git commit -m "docs: fix typo in installation guide"
+git push -u origin docs/fix-typo
+# Open PR via CLI
+gh pr create --title "docs: fix typo in installation guide" --body "Fixes typo in step 3"
+# Wait for CI (30 seconds)
+gh pr merge --squash --delete-branch
+```
+
+**Use GitHub CLI (`gh`) for speed:**
+```bash
+# Install
+brew install gh
+
+# Authenticate
+gh auth login
+
+# Create PR
+gh pr create
+
+# View PR status
+gh pr status
+
+# Merge when ready
+gh pr merge --squash --delete-branch
+```
+
+### Review Guidelines (Self-Review for Solo Dev)
+
+**When reviewing your own PR, check:**
+
+**Code quality:**
+- [ ] No commented-out code
+- [ ] No debug statements (`console.log`)
+- [ ] No TODOs without issue numbers
+- [ ] No hard-coded values (use env vars)
+- [ ] No secrets or credentials
+- [ ] Consistent code style (Prettier ran)
+
+**Testing:**
+- [ ] New features have tests
+- [ ] Bug fixes have regression tests
+- [ ] Tests are meaningful (not just coverage padding)
+- [ ] Edge cases covered
+
+**Security:**
+- [ ] User input validated
+- [ ] Output sanitized
+- [ ] No SQL injection vectors (using ORM)
+- [ ] No XSS vectors (DOMPurify for markdown)
+- [ ] Auth checks on protected routes
+
+**Accessibility (if UI changes):**
+- [ ] Semantic HTML used
+- [ ] Keyboard navigable
+- [ ] ARIA attributes where needed
+- [ ] Focus indicators visible
+- [ ] vitest-axe tests pass
+
+**Documentation:**
+- [ ] API changes reflected in OpenAPI spec
+- [ ] README updated if setup changed
+- [ ] Comments explain "why", not "what"
+
+### Commit Discipline
+
+**Commit frequently, push often:**
+- Small commits are easier to review and revert
+- Push to your branch regularly (backup)
+- Each commit should be a logical unit of work
+
+**Amending commits (use sparingly):**
+```bash
+# Only amend if:
+# 1. Commit not yet pushed, OR
+# 2. You're the only one on the branch
+
+git commit --amend --no-edit  # Fix without changing message
+git commit --amend            # Fix and change message
+```
+
+**Squashing before merge:**
+- PR will be squashed anyway (if using squash-merge)
+- Don't worry about messy WIP commits during development
+- Clean them up in PR description, not by force-pushing
+
+### When to Break the Rules
+
+**Direct commits to `main` are acceptable for:**
+- Emergency hotfixes in production (fix first, PR later for review)
+- README typos or trivial doc fixes (< 5 lines, no code)
+- Automated commits (Dependabot, release bots)
+
+**If you do commit directly:**
+1. Create a follow-up PR documenting what you did and why
+2. Tag it `hotfix` or `emergency`
+3. Link to incident report or issue
+
+### Branch Cleanup
+
+**After PR merge:**
+```bash
+# GitHub can auto-delete on merge (enable in repo settings)
+# Or manually:
+git checkout main
+git pull
+git branch -d feat/add-reactions  # Delete local
+git push origin --delete feat/add-reactions  # Delete remote (if not auto-deleted)
+```
+
+**Stale branches (older than 30 days, not merged):**
+- Review monthly
+- Close PR if no longer relevant
+- Delete branch if abandoned
+
+### Release Branches (Future - P2+)
+
+**When supporting multiple versions:**
+```
+main          (active development, becomes next major)
+release/v2    (v2.x maintenance, backport fixes)
+release/v1    (v1.x maintenance, security only)
+```
+
+**For now (pre-1.0):** Only `main` exists. No backports, only forward.
+
+---
+
+## Dependency Management
+
+### Version Policy
+
+**Rule: latest stable, always.** This is a new project. There is no legacy to maintain. Every dependency must be on the latest stable release unless there is a documented, specific technical blocker.
+
+- **Latest stable version** for all new dependencies. No exceptions.
+- **Never more than 1 minor version behind** on any package. If a package has a new stable major, upgrade to it within one month.
+- **LTS versions preferred** when a package offers an LTS track (e.g., Node.js 24 LTS).
+- **Pre-release versions (alpha, beta, RC) are not used** unless the package has no stable release and is required.
+- **Security patches are always applied to the latest version**, not backported to old majors.
+
+### pnpm Catalogs (Cross-Workspace Consistency)
+
+Dependencies shared across multiple workspace packages must be defined in the `catalog:` section of `pnpm-workspace.yaml`. Individual `package.json` files reference them with `catalog:` instead of version specifiers.
+
+**Why:** Prevents version drift where the same dependency resolves to different majors in different packages (e.g., zod v3 in web, zod v4 in api).
+
+**Catalog candidates** (shared across 2+ packages):
+
+```yaml
+# pnpm-workspace.yaml
+catalog:
+  zod: "^4.3.6"
+  vitest: "^4.0.18"
+  typescript: "^5.9.3"
+  typescript-eslint: "^8.55.0"
+  eslint: "^9.39.2"
+  "@types/node": "^25.2.3"
+  "@commitlint/cli": "^20.4.1"
+  "@commitlint/config-conventional": "^20.4.1"
+  "@vitest/coverage-v8": "^4.0.18"
+  husky: "^9.1.7"
+  multiformats: "^13.4.2"
+```
+
+**Usage in package.json:**
+```json
+{
+  "dependencies": {
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "vitest": "catalog:",
+    "typescript": "catalog:"
+  }
+}
+```
+
+**When adding a new shared dependency:** Add it to the catalog first, then reference `catalog:` in each package.json.
+
+### Adding New Dependencies
+
+Before adding any dependency:
+
+1. **Check if it already exists** in another workspace package. If so, use the same version (via catalog).
+2. **Use `pnpm add <package>@latest`** to get the latest stable version. Never copy a version specifier from a tutorial, blog post, or template without verifying it is current.
+3. **Verify the package is actively maintained.** Check: last publish date (< 6 months), open issues trend, Node.js version support.
+4. **Prefer packages with fewer transitive dependencies.** Run `pnpm why <package>` after install to understand the dependency tree.
+5. **Add to the pnpm catalog** if the dependency will be used in 2+ workspace packages.
+
+### Dependabot Configuration
+
+Dependabot is configured on all repos. The following rules apply:
+
+- **All update types enabled** including major versions. Do not ignore major updates.
+- **Weekly schedule** for dependency updates.
+- **Group minor/patch updates** into single PRs for reduced noise.
+- **Major updates get individual PRs** for easier review.
+- **Security updates are always auto-created** regardless of schedule.
+- **Auto-merge** minor/patch updates when CI passes (via GitHub auto-merge rules).
+
+### Monthly Dependency Review
+
+On the **first working day of each month**, run a dependency review:
+
+1. Run `pnpm outdated -r` in the workspace root.
+2. For each outdated package:
+   - **Patch/minor behind:** Update immediately (should have been caught by Dependabot).
+   - **Major behind:** Check the changelog for breaking changes, create a PR with necessary code changes.
+   - **Intentionally held back:** Document the reason in this section under "Version Exceptions."
+3. Run `pnpm audit` to check for known vulnerabilities.
+4. Verify all Dependabot PRs are processed (merged or closed with reason).
+
+### CI Dependency Freshness Check
+
+A CI step runs `pnpm outdated -r --format json` and posts a warning comment on PRs when dependencies are outdated. This does not block merges but provides visibility.
+
+### Version Exceptions
+
+Packages intentionally held at an older version. Each entry must have a reason and a target date for resolution.
+
+| Package | Held at | Latest | Reason | Target date |
+|---|---|---|---|---|
+| `eslint` | 9.x | 10.x | Ecosystem not ready (typescript-eslint, eslint-config-next) | Re-evaluate March 2026 |
+| `isomorphic-dompurify` | 2.x | 3.0.0-rc.2 | No stable v3 release | Upgrade when 3.0.0 stable ships |
+
+---
+
+## Development Environment
+
+### Required Tools
+- Node.js 24 LTS
+- Docker + Docker Compose (for PostgreSQL, Valkey, test PDS)
+- pnpm (fast, disk-efficient package manager)
+
+### Local Setup
+- `docker compose up -d` for database and cache
+- `pnpm install` for dependencies
+- `pnpm dev` for development server with hot reload
+- `pnpm test` for test suite
+- `pnpm lint` for linting
+- `pnpm typecheck` for TypeScript verification
+
+### Environment Variables
+- `.env.example` committed (with placeholder values)
+- `.env` in `.gitignore` (never committed)
+- Zod schema validation for all env vars at startup (fail fast on missing config)
+- No secrets in code or config files
+
+---
+
+## Code Review Checklist
+
+Every PR must be reviewed against:
+
+- [ ] Tests written (unit + integration where applicable)
+- [ ] Tests pass locally and in CI
+- [ ] No TypeScript errors or ESLint warnings
+- [ ] Input validation on all new endpoints/handlers
+- [ ] Output sanitization for user-generated content
+- [ ] No raw SQL (use ORM)
+- [ ] No `any` types
+- [ ] No `console.log` (use logger)
+- [ ] No secrets or credentials
+- [ ] Conventional commit message
+- [ ] Database migration included (if schema changed)
+- [ ] API documentation updated (if endpoints changed)
+- [ ] Accessibility: semantic HTML, keyboard navigable, ARIA attributes where needed
+- [ ] Accessibility: vitest-axe tests for new components
+- [ ] SEO: JSON-LD structured data on new page types
+- [ ] SEO: meta tags (title, description, canonical, OpenGraph) on new pages
+- [ ] Dependencies: new packages added at latest stable version
+- [ ] Dependencies: shared packages use `catalog:` from pnpm-workspace.yaml
+
+---
+
+## Language Standards
+
+### Gender-Neutral Writing
+
+All documentation, code examples, mock data, test fixtures, and user-facing text must use gender-neutral language.
+
+- **Example account:** `jay.bsky.team` (not alice.bsky.social). Jay is the Bluesky CEO's handle -- a fun insider reference that's also gender-neutral.
+- **Pronouns in docs:** Use "they/them/their" when referring to a hypothetical user. Never "he/she" or gendered pronouns.
+- **Example names in mock data and tests:** Use gender-neutral names. Preferred set: Jay, Alex, Sam, Robin, Morgan. Avoid gendered placeholder names (Alice, Bob, Carol, etc.).
+- **Variable names:** Match the example name (e.g., `didJay`, not `didAlice`).
+- **Inclusive phrasing:** "the user configures their profile" not "the user configures his or her profile".
+
+---
+
+## Documentation Strategy
+
+### Principle: docs that can't go stale
+
+Documentation is generated from code wherever possible. Manual docs are flagged for staleness in CI.
+
+### Auto-generated (zero maintenance)
+- **API docs:** @fastify/swagger generates OpenAPI 3.0 spec from Fastify routes + Zod schemas. Served interactively via @scalar/fastify-api-reference at `/docs`.
+- **TypeScript types:** Generated from lexicon JSON schemas via @atproto/lex-cli.
+- **Database schema:** Drizzle ORM schema files ARE the documentation.
+- **Lexicon format:** JSON schema files in barazo-lexicons repo.
+
+### Staleness detection (GitHub Action)
+- CI checks if code changes in `src/routes/` without corresponding docs changes.
+- Flags PR with a warning: "API code changed but docs not updated."
+- No LLM, no cost - just pattern matching.
+
+### npm Package Links
+- When referencing Barazo npm packages in docs, READMEs, or guides, link to `npmx.dev` instead of `npmjs.com`.
+- Example: `https://npmx.dev/package/@barazo/plugin-signatures`
+- Does not apply to CI configs, install commands, or registry API calls.
+
+### Manual docs (in repo, reviewed in PRs)
+- Architecture docs, guides, and README live in `docs/` directory.
+- Updated in the same PR as the code they describe.
+- ADRs (below) for significant technical decisions.
+
+### Future: LLM-assisted updates (P2+)
+- GitHub Action sends diffs to LLM on PR merge.
+- Opens draft PR with suggested doc updates.
+- Human reviews and merges.
+- Can use local Ollama or cheap API call.
+
+---
+
+## Architecture Decision Records (ADRs)
+
+Significant technical decisions should be documented as ADRs in `docs/adr/`:
+
+```
+docs/adr/
+  001-fastify-over-express.md
+  002-drizzle-orm-selection.md
+  003-reaction-system-design.md
+  ...
+```
+
+Format:
+- **Status:** Proposed / Accepted / Deprecated / Superseded
+- **Context:** What is the issue?
+- **Decision:** What did we decide?
+- **Consequences:** What are the trade-offs?
+
+---
+
+## Versioning & Release Strategy
+
+### Semantic Versioning
+
+All repos follow **strict semver** (MAJOR.MINOR.PATCH):
+
+- **MAJOR** - Breaking changes (e.g., lexicon field removals, API endpoint changes, database migrations requiring manual intervention)
+- **MINOR** - New features, backward-compatible (e.g., new endpoints, new optional lexicon fields)
+- **PATCH** - Bug fixes, no new features
+
+**Starting version:** All repos start at `0.1.0` (pre-1.0 signals "not production-ready yet")
+
+### Version Alignment Strategy
+
+**Question:** Should all 4 repos share the same version number?
+
+**Decision:** **Hybrid approach - coordinated majors, independent minors/patches**
+
+| Repo | Versioning Strategy | Example |
+|------|---------------------|---------|
+| **barazo-lexicons** | Independent semver (lexicon changes don't align with app releases) | `1.2.0` |
+| **barazo-api** | Coordinated majors with barazo-web, independent minors/patches | `2.5.3` |
+| **barazo-web** | Coordinated majors with barazo-api, independent minors/patches | `2.4.1` |
+| **barazo-deploy** | Coordinated majors with API+Web, independent minors/patches | `2.1.0` |
+
+**Rationale:**
+
+1. **Lexicons are independent** - Schema changes happen on their own timeline. A new optional field (`MINOR` bump) doesn't require app releases. Apps declare which lexicon versions they support.
+
+2. **API and Web share majors** - Breaking API changes (v1 → v2) usually require frontend changes. Coordinating major versions signals compatibility.
+
+3. **Independent minors/patches** - API can release bug fixes (2.5.3) without forcing a frontend release. Frontend can add UI features (2.4.1) without requiring API changes.
+
+4. **Deploy follows API+Web** - Major infra changes (Docker Compose v2) align with app majors, but minor tweaks (new env vars, docs) don't.
+
+### Version Compatibility Matrix
+
+Maintained in root README of each repo:
+
+**barazo-api `2.5.3` compatibility:**
+- Requires: `barazo-lexicons` `^1.0.0` (any 1.x version)
+- Compatible with: `barazo-web` `^2.0.0` (any 2.x version)
+- Requires: `barazo-deploy` `^2.0.0`
+
+**barazo-web `2.4.1` compatibility:**
+- Requires: `barazo-api` `^2.0.0` (any 2.x version)
+
+**barazo-deploy `2.1.0` supports:**
+- `barazo-api` `^2.0.0`
+- `barazo-web` `^2.0.0`
+
+### GitHub Releases
+
+**When to create a release:**
+- Every merge to `main` (automated via GitHub Actions)
+- Tag format: `v{MAJOR}.{MINOR}.{PATCH}` (e.g., `v0.1.0`, `v1.2.3`)
+
+**What's in a release:**
+- **Release notes** (auto-generated from conventional commits)
+- **Docker images** (pushed to GitHub Container Registry)
+- **npm package** (for barazo-lexicons only)
+- **Source code** (automatic GitHub archive)
+
+**Release automation (GitHub Actions):**
+
+```yaml
+# .github/workflows/release.yml
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    - Extract version from tag
+    - Build Docker image (API/Web only)
+    - Push to ghcr.io/barazo-forum/{repo}:latest
+    - Push to ghcr.io/barazo-forum/{repo}:{version}
+    - Generate changelog from commits since last tag
+    - Create GitHub Release with changelog
+    - (Lexicons only) Publish to GitHub Packages npm registry
+```
+
+### GitHub Packages
+
+**What gets published as packages:**
+
+| Repo | Package Type | Registry | Package Name |
+|------|-------------|----------|--------------|
+| barazo-lexicons | npm | GitHub Packages | `@singi-labs/barazo-lexicons` |
+| barazo-api | Docker | GitHub Container Registry | `ghcr.io/barazo-forum/barazo-api` |
+| barazo-web | Docker | GitHub Container Registry | `ghcr.io/barazo-forum/barazo-web` |
+| barazo-deploy | None | N/A | Git clone only |
+
+**Why GitHub Packages (not npmjs.com)?**
+- Free for public repos
+- Integrated with GitHub permissions
+- Same auth as Docker registry
+- Can switch to npmjs.com later if desired (namespace already reserved: `@barazo`)
+
+**npm package setup (barazo-lexicons only):**
+
+```json
+// package.json
+{
+  "name": "@singi-labs/barazo-lexicons",
+  "version": "1.2.0",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  }
+}
+```
+
+**Installing from GitHub Packages:**
+
+```bash
+# One-time setup: configure npm to use GitHub Packages for @barazo-forum scope
+echo "@barazo-forum:registry=https://npm.pkg.github.com" >> .npmrc
+
+# Install (works in barazo-api and barazo-web)
+pnpm add @singi-labs/barazo-lexicons
+```
+
+### Docker Image Tagging Strategy
+
+**Tags pushed on each release:**
+
+```bash
+# Example: releasing barazo-api v2.5.3
+ghcr.io/barazo-forum/barazo-api:latest        # Always points to most recent release
+ghcr.io/barazo-forum/barazo-api:2             # Latest 2.x version
+ghcr.io/barazo-forum/barazo-api:2.5           # Latest 2.5.x version
+ghcr.io/barazo-forum/barazo-api:2.5.3         # Exact version (immutable)
+```
+
+**Staging always uses `latest`:**
+```yaml
+# docker-compose.staging.yml
+services:
+  barazo-api:
+    image: ghcr.io/barazo-forum/barazo-api:latest
+```
+
+**Production uses pinned versions:**
+```yaml
+# docker-compose.yml (user deploys)
+services:
+  barazo-api:
+    image: ghcr.io/barazo-forum/barazo-api:2.5.3
+```
+
+**Why pin in production?**
+- Prevents surprise breakage from `latest` updates
+- Users explicitly upgrade via `docker compose pull` + tag change
+- Rollback is trivial (change tag back)
+
+### Coordinated Major Release Process
+
+**When releasing a breaking change (e.g., v1 → v2):**
+
+1. **Plan the release** - What's breaking? Which repos need updates?
+2. **Version bumps** - Coordinate `package.json` version bumps in same PR or same day
+3. **Tag all repos** - Tag on the same day:
+   ```bash
+   # barazo-api
+   git tag v2.0.0 && git push origin v2.0.0
+   
+   # barazo-web
+   git tag v2.0.0 && git push origin v2.0.0
+   
+   # barazo-deploy
+   git tag v2.0.0 && git push origin v2.0.0
+   
+   # barazo-lexicons (if breaking schema change)
+   git tag v2.0.0 && git push origin v2.0.0
+   ```
+4. **Release notes** - Coordinated release announcement (blog post, Bluesky)
+5. **Migration guide** - Document upgrade path (database migrations, config changes)
+
+**GitHub Releases convention for coordinated majors:**
+- Title: `v2.0.0 - Barazo Major Release` (all repos use same title)
+- Body includes: breaking changes, migration guide, compatibility matrix
+
+### Pre-1.0 Versioning (MVP P1)
+
+**During P1 (pre-production):**
+- Versions: `0.1.0`, `0.2.0`, `0.3.0`, etc.
+- Breaking changes = `MINOR` bump (not `MAJOR`)
+- This is standard semver behavior for 0.x versions
+
+**When to go 1.0.0:**
+- P2 launch (self-hosting release)
+- Signals: "production-ready, stable API, semver guarantees enforced"
+
+**Pre-1.0 example timeline:**
+```
+v0.1.0  - Initial proof-of-concept (firehose works)
+v0.2.0  - MVP features complete (topics, replies, reactions)
+v0.3.0  - Staging deployed, OAuth working
+v0.5.0  - All P1 milestones complete
+v1.0.0  - P2 launch (self-hosting documentation, stable API)
+```
+
+### Changelog Generation
+
+**Automated via conventional commits:**
+
+GitHub Actions uses commit messages to generate changelogs:
+
+```bash
+# Extracts commits since last tag
+git log v0.4.0..HEAD --format="%s"
+
+# Groups by type
+feat(appview): add firehose subscription
+fix(frontend): sanitize markdown output
+docs(api): update OAuth setup guide
+```
+
+**Rendered in GitHub Release:**
+```markdown
+## Features
+- **appview**: add firehose subscription (#42)
+
+## Bug Fixes
+- **frontend**: sanitize markdown output (#43)
+
+## Documentation
+- **api**: update OAuth setup guide (#44)
+```
+
+**Tool:** `conventional-changelog` or GitHub's auto-generated release notes
+
+### Version Bumping Workflow
+
+**Manual bump (for now):**
+```bash
+# Update package.json version
+pnpm version minor  # or major, or patch
+
+# Creates commit + tag automatically
+# Push to trigger release
+git push && git push --tags
+```
+
+**Future automation (P2+):**
+- Use `semantic-release` to auto-bump based on conventional commits
+- PR merged with `feat:` → auto-bump minor, tag, release
+- PR merged with `BREAKING CHANGE:` → auto-bump major
+
+### Rollback Strategy
+
+**If a release breaks production:**
+
+1. **Immediate fix** - Revert to previous Docker tag:
+   ```bash
+   # In docker-compose.yml
+   image: ghcr.io/barazo-forum/barazo-api:2.5.2  # Was 2.5.3
+   docker compose up -d
+   ```
+
+2. **Fix forward** - Patch the bug, release `2.5.4`
+
+3. **GitHub Release** - Mark broken release as "Pre-release" or add warning
+
+**Database migration rollback:**
+- Drizzle migrations are forward-only (no automatic rollback)
+- Critical: test migrations on staging first
+- Emergency: restore from backup, re-run migrations up to working version
+
+### Version Communication
+
+**Where versions are visible:**
+
+| Location | Purpose |
+|----------|---------|
+| GitHub Releases | Changelog, download links |
+| Docker tags | Deployment |
+| API response | `GET /api/health` returns `{ version: "2.5.3" }` |
+| Frontend footer | "Powered by Barazo v2.5.3" |
+| npm package | `@singi-labs/barazo-lexicons@1.2.0` |
+
+**Health endpoint includes versions:**
+```json
+GET /api/health
+{
+  "status": "healthy",
+  "version": "2.5.3",
+  "lexicons": "^1.0.0",
+  "uptime": 86400
+}
+```
+
+### Future: Monorepo Consideration
+
+**Not now, but possible later:**
+
+If cross-repo coordination becomes painful:
+- Move all 4 repos into a monorepo (pnpm workspaces or Turborepo)
+- Single version number for all packages
+- Easier to coordinate breaking changes
+- Shared tooling (ESLint, TypeScript config, CI)
+
+**Defer until:** We have real pain from multi-repo coordination (probably not until P3+)
+
+---
+
+## References
+
+- AT Protocol Security: https://atproto.com/guides/security
+- OWASP Top 10: https://owasp.org/www-project-top-ten/
+- Drizzle ORM: https://orm.drizzle.team/
+- Valkey: https://valkey.io/


### PR DESCRIPTION
Adds the contributor-facing standards under `engineering/standards/` (canonical home; AGENTS.md references them instead of copying):

`shared`, `backend`, `frontend`, `atproto-conventions`, `naming-lexicon`, `quality-measures`, `readme-template`.

**Secrets check:** each doc was swept for secrets, hostnames, IPs, DSNs, internal paths, and person names before publishing. `backend.md` names infra tech (Hetzner, self-hosted GlitchTip) and env-var *names* only — no values. The runbook, maintainer lifecycle, and infra-detailed harness were withheld → see the `.internal` PR.

Updates `engineering/README.md` with the standards index.