### PR TITLE
feat(ai-review): wire reviewer to canonical engineering/standards

### DIFF
--- a/.github/workflows/ai-review-reusable.yml
+++ b/.github/workflows/ai-review-reusable.yml
@@ -81,6 +81,23 @@ jobs:
           echo "mode=$mode" >> "$GITHUB_OUTPUT"
           echo "Scoped: profile=${{ inputs.profile }}, mode=$mode, diff lines=$lines"
 
+      - name: Assemble standards context
+        if: steps.scope.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          : > combined-standards.md
+          # Repo house rules (AGENTS.md preferred, else CLAUDE.md)
+          for f in AGENTS.md CLAUDE.md; do
+            if [ -f "$f" ]; then cat "$f" >> combined-standards.md; printf '\n\n' >> combined-standards.md; break; fi
+          done
+          # Canonical engineering standards for this profile (single source of truth in .github)
+          std=".singi-review/engineering/standards"
+          if [ "${{ inputs.profile }}" = "frontend" ]; then
+            [ -f "$std/frontend.md" ] && cat "$std/frontend.md" >> combined-standards.md || true
+          else
+            [ -f "$std/backend.md" ] && cat "$std/backend.md" >> combined-standards.md || true
+          fi
+
       - name: Run AI review
         if: steps.scope.outputs.skip != 'true'
         id: run
@@ -93,7 +110,7 @@ jobs:
           GENERAL_PROMPT: ${{ steps.prof.outputs.general }}
           ADVERSARIAL_PROMPT: ${{ steps.prof.outputs.adversarial }}
           DIFF_FILE: diff.patch
-          STANDARDS_FILE: CLAUDE.md
+          STANDARDS_FILE: combined-standards.md
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
         run: node .singi-review/scripts/ai-review/review.mjs > review.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,9 @@ cd <repo>
 2. Branch from `main`: `git checkout -b feat/short-description`.
 3. Build it **with tests**. Run the repo's test/lint/typecheck locally.
 4. Open a PR, link the issue (`Closes #NN`), fill the checklist.
-5. **Two things review your PR:**
+5. **Automated gates + human review on your PR:**
+   - a **secret scan** (gitleaks) blocks any committed secret — if a test fixture
+     trips it, allowlist the fake value in the repo's `.gitleaks.toml`;
    - an **automated AI reviewer** posts a comment and a **blocking `AI Review`
      check** — if it requests changes, address them and push (it re-runs);
    - a **maintainer** reviews and merges (squash).

--- a/scripts/ai-review/review.mjs
+++ b/scripts/ai-review/review.mjs
@@ -40,7 +40,7 @@ const diff = truncated ? rawDiff.slice(0, MAX_DIFF) : rawDiff;
 
 const standards =
   env.STANDARDS_FILE && existsSync(env.STANDARDS_FILE)
-    ? readFileSync(env.STANDARDS_FILE, "utf8").slice(0, 8000)
+    ? readFileSync(env.STANDARDS_FILE, "utf8").slice(0, 16000)
     : "";
 const prTitle = env.PR_TITLE || "";
 const prBody = (env.PR_BODY || "").slice(0, 4000);


### PR DESCRIPTION
The reviewer was carrying a hand-distilled copy of the standards in its prompts, which would drift from `engineering/standards/`. The reusable workflow already checks out this repo, so it now assembles the standards context from the repo's `AGENTS.md` + the canonical `engineering/standards/{backend,frontend}.md` for the profile — single source of truth, no drift. Cap raised 8k→16k to fit a standards doc. Also adds the gitleaks secret-scan gate to CONTRIBUTING.