### PR TITLE
ci(ai-review): exclude lockfiles/snapshots from the review diff

### DIFF
--- a/.github/workflows/ai-review-reusable.yml
+++ b/.github/workflows/ai-review-reusable.yml
@@ -73,7 +73,18 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"; echo "Skipping: only trivial files changed"; exit 0
           fi
           echo "skip=false" >> "$GITHUB_OUTPUT"
-          gh pr diff "$PR" --patch > diff.patch
+          # Drop generated, high-volume files (lockfiles, snapshots) from the
+          # review diff. review.mjs caps the diff at MAX_DIFF_CHARS (120k); a
+          # single regenerated pnpm-lock.yaml or package-lock deletion is bigger
+          # than that on its own and would truncate the real code out of view
+          # (the reviewer then flags "no tests" for changes it never saw). The
+          # awk drops each `diff --git ... b/<path>` section whose path is a
+          # lockfile or snapshot; everything else (incl. .github/ and docs) is
+          # kept. A PR that changes ONLY trivial files is already skipped above.
+          gh pr diff "$PR" --patch | awk '
+            /^diff --git / { p = $0; sub(/^diff --git a\/.* b\//, "", p);
+              drop = (p ~ /(\.lock|lock\.json|lock\.ya?ml|\.snap)$/) }
+            !drop' > diff.patch
           lines=$(wc -l < diff.patch)
           mode=single
           printf '%s' "$LABELS" | grep -q 'deep-review' && mode=dual || true


### PR DESCRIPTION
## Problem

`review.mjs` caps the diff it sends to the model at `MAX_DIFF_CHARS` (120k). A regenerated `pnpm-lock.yaml` or a `package-lock.json` deletion is larger than that budget on its own, so on migration-shaped PRs the lockfile churn pushed the actual code past the cap. The reviewer then reviewed a truncated diff and flagged "no tests" for source it never saw.

Observed on `singi-labs/sifa-api#829` (the npm-to-pnpm switch): the raw patch was 576k chars, so `src/` and `tests/` were truncated out entirely.

## Change

Filter `diff.patch` before review to drop generated, high-volume file sections (lockfiles and snapshots) with a small awk pass on the `diff --git ... b/<path>` boundaries. Everything else is kept, including `.github/` workflows and docs, which are still worth reviewing.

On the #829 diff this brings the reviewed patch from 576k to 47k chars, well under the cap, so the reviewer sees the full code and tests.

## Notes

- No behaviour change for normal PRs (nothing to drop).
- PRs that change only trivial files are already skipped upstream, so this never produces an empty diff.
- The `mode=dual` line-count threshold now reflects real code size rather than lockfile noise.
