### PR TITLE
copy: retagline to "Open foundations for your online life"

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -21,39 +21,27 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const repos = ['barazo-api', 'barazo-web', 'barazo-lexicons', 'barazo-deploy', 'barazo-website'];
-            const seen = new Map();
+            // Curated contributor list. listContributors only counts public-repo
+            // commits, so it missed external contributors working on private Sifa
+            // repos. Fetch each user's current avatar by login instead. Add new
+            // contributors here.
+            const logins = ['gxjansen', 'StevenLangbroek', 'nmokkenstorm'];
+            const cells = [];
 
-            for (const repo of repos) {
+            for (const login of logins) {
               try {
-                const { data } = await github.rest.repos.listContributors({
-                  owner: 'singi-labs',
-                  repo,
-                  per_page: 100,
-                });
-                for (const c of data) {
-                  if (c.type !== 'User') continue;
-                  if (!seen.has(c.login)) {
-                    seen.set(c.login, { login: c.login, avatar: c.avatar_url, contributions: 0 });
-                  }
-                  seen.get(c.login).contributions += c.contributions;
-                }
+                const { data } = await github.rest.users.getByUsername({ username: login });
+                cells.push(
+                  `<a href="https://github.com/${data.login}"><img src="${data.avatar_url}&s=80" width="80" alt="@${data.login}" /></a>`
+                );
               } catch (e) {
-                console.log(`Skipping ${repo}: ${e.message}`);
+                console.log(`Skipping ${login}: ${e.message}`);
               }
             }
 
-            const contributors = [...seen.values()]
-              .sort((a, b) => b.contributions - a.contributions);
-
-            const cells = contributors.map(c =>
-              `<a href="https://github.com/${c.login}"><img src="${c.avatar}&s=80" width="80" alt="@${c.login}" /></a>`
-            );
-
             const fs = require('fs');
-            const md = cells.join('\n');
-            fs.writeFileSync('contributors-fragment.html', md);
-            console.log(`Generated ${contributors.length} contributors`);
+            fs.writeFileSync('contributors-fragment.html', cells.join('\n'));
+            console.log(`Generated ${cells.length} contributors`);
 
       - name: Update README
         run: |

--- a/assets/banner-singi.svg
+++ b/assets/banner-singi.svg
@@ -55,7 +55,7 @@
             <text x="0" y="0" style="font-family:'Helvetica-Bold','Helvetica','Arial',sans-serif;font-weight:700;font-size:76px;fill:#FFFCF0;">Singi Labs</text>
         </g>
         <g transform="translate(80,195)">
-            <text x="0" y="0" style="font-family:'Helvetica','Arial',sans-serif;font-size:28px;fill:#FFFCF0;">Open community infrastructure for the decentralized web</text>
+            <text x="0" y="0" style="font-family:'Helvetica','Arial',sans-serif;font-size:28px;fill:#FFFCF0;">Open foundations for your online life.</text>
         </g>
         <rect x="80" y="210" width="140" height="2" style="fill:#DA702C;fill-opacity:0.6;"/>
     </g>

--- a/engineering/agent-instructions.md
+++ b/engineering/agent-instructions.md
@@ -11,8 +11,8 @@ Singi Labs context — safe to use anywhere.
 
 ## Project
 
-You are contributing to a **Singi Labs** repo — open foundations for networked apps
-on the AT Protocol. Products: **Barazo** (federated forum) and **Sifa**
+You are contributing to a **Singi Labs** repo — open foundations for your online life
+on AT Protocol. Products: **Barazo** (federated forum) and **Sifa**
 (professional identity). The repo's own `README.md` / `AGENTS.md` has the exact
 stack, package manager, and setup. General shape: TypeScript (strict), Node current
 LTS, npm or pnpm per repo, PostgreSQL + Drizzle and Valkey on the backends, Next.js

--- a/profile/README.md
+++ b/profile/README.md
@@ -2,7 +2,7 @@
 
 **Open source foundations for the parts of your online life you shouldn't have to rent.**
 
-We build decentralized software on the [AT Protocol](https://atproto.com). Portable identity, user-owned data, no ads.
+We build in the open on [AT Protocol](https://atproto.com). Portable identity, user-owned data, no ads.
 
 Made with ♥ in 🇪🇺.
 
@@ -34,16 +34,18 @@ Federated forums on the AT Protocol. Self-hostable. One account works across eve
 
 ![Sifa](https://raw.githubusercontent.com/singi-labs/.github/main/assets/banner-sifa.svg)
 
-Professional identity and career network on the AT Protocol. Portable profiles, verifiable track record from real community contributions, no vendor lock-in. The LinkedIn alternative for the decentralized web.
+Professional identity and career network on the AT Protocol. Portable profiles, verifiable track record from real community contributions, no vendor lock-in. The LinkedIn alternative for the open web.
 
 **Status:** Alpha (P1 MVP complete)
-**License:** MIT (lexicons)
+**License:** MIT (SDK, lexicons)
 
 | Repository | Description | CI | Updated |
 |------------|-------------|----|---------|
+| [sifa-sdk](https://github.com/singi-labs/sifa-sdk) | Public TypeScript client for the Sifa AppView (on npm) | [![CI](https://github.com/singi-labs/sifa-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/singi-labs/sifa-sdk/actions/workflows/ci.yml) | ![Updated](https://img.shields.io/github/last-commit/singi-labs/sifa-sdk?label=updated) |
 | [sifa-lexicons](https://github.com/singi-labs/sifa-lexicons) | AT Protocol professional profile schemas (MIT) | [![Validate](https://github.com/singi-labs/sifa-lexicons/actions/workflows/validate.yml/badge.svg)](https://github.com/singi-labs/sifa-lexicons/actions/workflows/validate.yml) | ![Updated](https://img.shields.io/github/last-commit/singi-labs/sifa-lexicons?label=updated) |
+| [sifa-docs](https://github.com/singi-labs/sifa-docs) | Documentation site (Fumadocs) | [![CI](https://github.com/singi-labs/sifa-docs/actions/workflows/ci.yml/badge.svg)](https://github.com/singi-labs/sifa-docs/actions/workflows/ci.yml) | ![Updated](https://img.shields.io/github/last-commit/singi-labs/sifa-docs?label=updated) |
 
-[sifa.id](https://sifa.id)
+[sifa.id](https://sifa.id) | [Documentation](https://docs.sifa.id)
 
 ---
 
@@ -70,6 +72,8 @@ Contributions are welcome. See [CONTRIBUTING.md](https://github.com/singi-labs/.
 
 <!-- CONTRIBUTORS:START -->
 <a href="https://github.com/gxjansen"><img src="https://avatars.githubusercontent.com/u/487722?v=4&s=80" width="80" alt="@gxjansen" /></a>
+<a href="https://github.com/StevenLangbroek"><img src="https://avatars.githubusercontent.com/u/296796?v=4&s=80" width="80" alt="@StevenLangbroek" /></a>
+<a href="https://github.com/nmokkenstorm"><img src="https://avatars.githubusercontent.com/u/33529698?v=4&s=80" width="80" alt="@nmokkenstorm" /></a>
 <!-- CONTRIBUTORS:END -->
 
 ---

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,6 @@
 ![Singi Labs](https://raw.githubusercontent.com/singi-labs/.github/main/assets/banner-singi.svg)
 
-**Open source foundations for networked apps.**
+**Open source foundations for the parts of your online life you shouldn't have to rent.**
 
 We build decentralized software on the [AT Protocol](https://atproto.com). Portable identity, user-owned data, no ads.
 


### PR DESCRIPTION
## What

Retaglines the org profile to "Open foundations for your online life" and refreshes the stale profile README.

## Tagline

Two problems with the old copy:

1. The README subtitle read "Open source foundations for networked apps." That positions Singi below apps in the AT Protocol stack, an overclaim to a protocol-literate reader.
2. The banner SVG led with "Open community infrastructure for the decentralized web". Leading with "decentralized" goes against our own voice guide. Most people do not care, so we use portable, open, and yours instead.

Both now anchor "foundation" to the person's online life: identity, work, community.

## Profile refresh

The README had drifted:

- **Contributors block was stuck on one person.** `update-contributors.yml` counted commits across the public Barazo repos only, so external contributors working on the private Sifa repos never showed up. Rewrote it to fetch avatars from a curated login list, and added Steven Langbroek and Niels Mokkenstorm.
- **Sifa section only listed lexicons.** Added the public repos that were missing: `sifa-sdk` (on npm) and `sifa-docs`, plus a docs.sifa.id link. Bumped the license line to `MIT (SDK, lexicons)`.
- **Dropped the two "decentralized" leads** (intro line and the Sifa one-liner) per the voice guide.

## Changed

- `profile/README.md`: subtitle, banner reference, Sifa repo table, contributors block, voice fixes
- `assets/banner-singi.svg`: tagline line to `Open foundations for your online life.` It is shorter than the old line, so no layout change was needed.
- `engineering/agent-instructions.md`: one-liner, plus normalizes the protocol name to drop the leading article.
- `.github/workflows/update-contributors.yml`: curated login list instead of commit-counting

## Not verified

Status lines ("Phase 2 complete" for Barazo, "P1 MVP complete" for Sifa) were left as-is. The README body line about building decentralized software still leads with "decentralized" in one spot the tables reference. Flagging both for a follow-up if they need a check.
