### PR TITLE
docs: refresh org profile — Sifa first, banner + links cleanup

### DIFF
--- a/assets/banner-sifa.svg
+++ b/assets/banner-sifa.svg
@@ -55,7 +55,7 @@
             <text x="0" y="0" style="font-family:'Helvetica-Bold','Helvetica','Arial',sans-serif;font-weight:700;font-size:76px;fill:#FFFCF0;">Sifa</text>
         </g>
         <g transform="translate(80,195)">
-            <text x="0" y="0" style="font-family:'Helvetica','Arial',sans-serif;font-size:28px;fill:#FFFCF0;">Professional profiles and reputation</text>
+            <text x="0" y="0" style="font-family:'Helvetica','Arial',sans-serif;font-size:28px;fill:#FFFCF0;">Your professional identity, portable</text>
         </g>
         <rect x="80" y="210" width="140" height="2" style="fill:#4385BE;fill-opacity:0.6;"/>
     </g>

--- a/profile/README.md
+++ b/profile/README.md
@@ -4,14 +4,27 @@
 
 We build in the open on [AT Protocol](https://atproto.com). Portable identity, user-owned data, no ads.
 
-Made with ♥ in 🇪🇺.
-
 [![GitHub Org Stars](https://img.shields.io/github/stars/singi-labs?style=flat&label=total%20org%20stars)](https://github.com/singi-labs)
 [![Website](https://img.shields.io/badge/singi.dev-website-DA702C)](https://singi.dev)
 
 ---
 
 ## Products
+
+![Sifa](https://raw.githubusercontent.com/singi-labs/.github/main/assets/banner-sifa.svg)
+
+Professional identity and career network on the AT Protocol. Portable profiles, verifiable track record from real community contributions, no vendor lock-in. The LinkedIn alternative for the open web.
+
+**Status:** Alpha (P1 MVP complete)
+**License:** MIT (SDK, lexicons)
+
+| Repository | Description | CI | Updated |
+|------------|-------------|----|---------|
+| [sifa-sdk](https://github.com/singi-labs/sifa-sdk) | Public TypeScript client for the Sifa AppView (on npm) | [![CI](https://github.com/singi-labs/sifa-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/singi-labs/sifa-sdk/actions/workflows/ci.yml) | ![Updated](https://img.shields.io/github/last-commit/singi-labs/sifa-sdk?label=updated) |
+| [sifa-lexicons](https://github.com/singi-labs/sifa-lexicons) | AT Protocol professional profile schemas (MIT) | [![Validate](https://github.com/singi-labs/sifa-lexicons/actions/workflows/validate.yml/badge.svg)](https://github.com/singi-labs/sifa-lexicons/actions/workflows/validate.yml) | ![Updated](https://img.shields.io/github/last-commit/singi-labs/sifa-lexicons?label=updated) |
+| [sifa-docs](https://github.com/singi-labs/sifa-docs) | Documentation site (Fumadocs) | | ![Updated](https://img.shields.io/github/last-commit/singi-labs/sifa-docs?label=updated) |
+
+[sifa.id](https://sifa.id) | [Documentation](https://docs.sifa.id)
 
 ![Barazo](https://raw.githubusercontent.com/singi-labs/.github/main/assets/banner-barazo.svg)
 
@@ -31,21 +44,6 @@ Federated forums on the AT Protocol. Self-hostable. One account works across eve
 | [barazo-website](https://github.com/singi-labs/barazo-website) | Marketing site | | ![Updated](https://img.shields.io/github/last-commit/singi-labs/barazo-website?label=updated) |
 
 [barazo.forum](https://barazo.forum) | [Documentation](https://docs.barazo.forum)
-
-![Sifa](https://raw.githubusercontent.com/singi-labs/.github/main/assets/banner-sifa.svg)
-
-Professional identity and career network on the AT Protocol. Portable profiles, verifiable track record from real community contributions, no vendor lock-in. The LinkedIn alternative for the open web.
-
-**Status:** Alpha (P1 MVP complete)
-**License:** MIT (SDK, lexicons)
-
-| Repository | Description | CI | Updated |
-|------------|-------------|----|---------|
-| [sifa-sdk](https://github.com/singi-labs/sifa-sdk) | Public TypeScript client for the Sifa AppView (on npm) | [![CI](https://github.com/singi-labs/sifa-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/singi-labs/sifa-sdk/actions/workflows/ci.yml) | ![Updated](https://img.shields.io/github/last-commit/singi-labs/sifa-sdk?label=updated) |
-| [sifa-lexicons](https://github.com/singi-labs/sifa-lexicons) | AT Protocol professional profile schemas (MIT) | [![Validate](https://github.com/singi-labs/sifa-lexicons/actions/workflows/validate.yml/badge.svg)](https://github.com/singi-labs/sifa-lexicons/actions/workflows/validate.yml) | ![Updated](https://img.shields.io/github/last-commit/singi-labs/sifa-lexicons?label=updated) |
-| [sifa-docs](https://github.com/singi-labs/sifa-docs) | Documentation site (Fumadocs) | [![CI](https://github.com/singi-labs/sifa-docs/actions/workflows/ci.yml/badge.svg)](https://github.com/singi-labs/sifa-docs/actions/workflows/ci.yml) | ![Updated](https://img.shields.io/github/last-commit/singi-labs/sifa-docs?label=updated) |
-
-[sifa.id](https://sifa.id) | [Documentation](https://docs.sifa.id)
 
 ---
 
@@ -81,9 +79,10 @@ Contributions are welcome. See [CONTRIBUTING.md](https://github.com/singi-labs/.
 ## Links
 
 - [singi.dev](https://singi.dev) -- Organization homepage
+- [sifa.id](https://sifa.id) -- Sifa professional network
+- [docs.sifa.id](https://docs.sifa.id) -- Sifa documentation
 - [barazo.forum](https://barazo.forum) -- Barazo marketing site
 - [docs.barazo.forum](https://docs.barazo.forum) -- Barazo documentation
-- [sifa.id](https://sifa.id) -- Sifa professional network
 - 🦋 [Bluesky](https://bsky.app/profile/singi.dev) -- @singi.dev
 
 ---


### PR DESCRIPTION
## What

Tidies the org profile README and updates the Sifa banner.

## Changes

- **Sifa first.** Moved the Sifa product block above Barazo, in both the Products and Links sections.
- **Sifa banner tagline.** `Professional profiles and reputation` to `Your professional identity, portable`. "Reputation" is the earned-trust network-effect layer, which the voice guide keeps out of taglines until it ships and has traction. Portability is the day-1 truth.
- **sifa-docs CI badge removed.** It rendered a misleading red. The badge was not reflecting a real failure: `ci.yml` in sifa-docs only runs on pull requests (no push-to-main trigger), and the most recent runs are the automated `chore/screenshots-*` bot PRs sitting in `action_required`. The code checks themselves pass on feature branches. Dropping the badge matches barazo-docs and barazo-website, which already show no CI badge.
- **Added the docs.sifa.id link** in the Links section.
- **Removed the duplicate footer line.** "Made with love in EU" appeared twice; kept the footer copy, dropped the one near the top.

## Follow-ups (not in this PR)

- The `chore/screenshots-*` PRs in sifa-docs are stuck in `action_required` and need a maintainer to approve their workflow runs.
- If you want a real green CI badge on sifa-docs later, add a `push: [main]` trigger to its `ci.yml`.
