### PR TITLE
ci: add runner input to reusable workflows

### DIFF
--- a/.github/workflows/ai-review-reusable.yml
+++ b/.github/workflows/ai-review-reusable.yml
@@ -14,6 +14,10 @@ on:
         description: "Prompt set: backend | frontend"
         type: string
         default: backend
+      runner:
+        description: "Runner label(s) to execute on. Defaults to GitHub-hosted; sifa callers pass a self-hosted label to avoid billed minutes."
+        type: string
+        default: ubuntu-latest
     secrets:
       OPENROUTER_API_KEY:
         required: true
@@ -29,7 +33,7 @@ jobs:
       (github.event.action != 'labeled' ||
        github.event.label.name == 'deep-review' ||
        github.event.label.name == 're-review') }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/dependency-diff-reusable.yml
+++ b/.github/workflows/dependency-diff-reusable.yml
@@ -21,11 +21,15 @@ on:
         description: "Warn when install size grows beyond this (bytes)"
         type: number
         default: 100000
+      runner:
+        description: "Runner label(s) to execute on. Defaults to GitHub-hosted; sifa callers pass a self-hosted label to avoid billed minutes."
+        type: string
+        default: ubuntu-latest
 
 jobs:
   dependency-diff:
     if: ${{ github.event.pull_request.draft == false }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -15,11 +15,15 @@ on:
         description: gitleaks container tag to pin
         type: string
         default: "v8.30.1"
+      runner:
+        description: "Runner label(s) to execute on. Defaults to GitHub-hosted; sifa callers pass a self-hosted label to avoid billed minutes."
+        type: string
+        default: ubuntu-latest
 
 jobs:
   gitleaks:
     name: gitleaks
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Why

singi-labs hit 90% of included Actions minutes. Heavy CI and E2E already run on the self-hosted `self-hosted-sifa` runners, but the reusable workflows (AI review, secret-scan, dependency-diff) are hardcoded to `ubuntu-latest` and burn billed minutes on every PR. AI review alone is about 800 min/month across sifa-api and sifa-web, most of it idle wall-clock waiting on OpenRouter.

## What

Add an optional `runner` input to the three reusable workflows:

- `ai-review-reusable.yml`
- `secret-scan.yml`
- `dependency-diff-reusable.yml`

The default stays `ubuntu-latest`, so public barazo repos keep running free GitHub-hosted with zero change. Private sifa callers pass `runner: self-hosted-sifa` in follow-up PRs (sifa-api, sifa-web).

## Merge order

Merge this first. The sifa caller PRs pass `with: { runner: self-hosted-sifa }`, which errors against `@main` until this input exists.

## Risk

None to existing callers. The input is additive and backward-compatible, with the current value as its default.
