### PR TITLE
fix(ai-review): never skip a label event without posting a status

### DIFF
--- a/.github/workflows/ai-review-reusable.yml
+++ b/.github/workflows/ai-review-reusable.yml
@@ -5,7 +5,8 @@ name: AI PR Review (reusable)
 #
 # Posts a comment + a BLOCKING "AI Review" status (fails on request_changes).
 # Always posts the status (skip/bot/error -> success) so a required check never
-# jams. Fails OPEN on reviewer/infra error. See scripts/ai-review/README.md.
+# jams: nothing may skip out of the run without leaving the head commit a
+# status. Fails OPEN on reviewer/infra error. See scripts/ai-review/README.md.
 
 on:
   workflow_call:
@@ -27,12 +28,51 @@ env:
   ADVERSARIAL_MODEL: z-ai/glm-5.2
 
 jobs:
+  # Label events only. A label that is not a review request must not spend a
+  # review, but it must not leave the commit without an "AI Review" status
+  # either: this job used to be expressed as a job-level `if`, and a skipped job
+  # posts nothing, so the required check jammed forever with nothing to re-run.
+  # Dependabot hit this every time -- it labels its own PR, and that label event
+  # cancels the in-flight review for the same SHA via the caller's concurrency
+  # group, leaving a commit no review would ever report on again.
+  gate:
+    if: github.event.action == 'labeled'
+    runs-on: ${{ inputs.runner }}
+    permissions:
+      contents: read
+      statuses: read
+    outputs:
+      stop: ${{ steps.check.outputs.stop }}
+    steps:
+      - name: Decide whether this label needs a review
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+          LABEL: ${{ github.event.label.name }}
+        run: |
+          set -euo pipefail
+          case "$LABEL" in
+            deep-review|re-review)
+              echo "Label '$LABEL' asks for a fresh review."; exit 0;;
+          esac
+          existing=$(gh api "repos/$REPO/commits/$SHA/status" \
+            --jq '.statuses[] | select(.context == "AI Review") | .state' | head -1)
+          if [ -n "${existing:-}" ]; then
+            echo "stop=true" >> "$GITHUB_OUTPUT"
+            echo "Label '$LABEL' is not a review request and $SHA already has an AI Review status ($existing). Nothing to do."
+          else
+            echo "Label '$LABEL' is not a review request, but $SHA has no AI Review status yet. Reviewing so the check can resolve."
+          fi
+
   review:
+    needs: gate
+    # `!cancelled()` rather than `success()`: gate is skipped on every
+    # non-label event, and a skipped dependency must not skip the review.
     if: >-
-      ${{ github.event.pull_request.draft == false &&
-      (github.event.action != 'labeled' ||
-       github.event.label.name == 'deep-review' ||
-       github.event.label.name == 're-review') }}
+      ${{ !cancelled() && github.event.pull_request.draft == false &&
+      needs.gate.outputs.stop != 'true' }}
     runs-on: ${{ inputs.runner }}
     permissions:
       contents: read

--- a/scripts/ai-review/README.md
+++ b/scripts/ai-review/README.md
@@ -39,14 +39,18 @@ the reusable workflow's "Select prompts" step.
    (synchronize) / ready**, plus the `deep-review` / `re-review` labels. It
    re-reviews on each push so a flagged PR can recover after fixes (required for
    a blocking gate). Concurrency cancels superseded runs so you don't pay twice.
-2. It **scopes** the PR — skips drafts, bot authors, and trivial-only PRs
+2. A **gate** job handles label events: a label that is not `deep-review` /
+   `re-review` spends no review, unless the head commit has no `AI Review`
+   status yet — then it reviews anyway, because a label event cancels the
+   in-flight run for that commit and nothing else would ever report on it.
+3. It **scopes** the PR — skips drafts, bot authors, and trivial-only PRs
    (docs, `*.md`, `.github/`, lockfiles, snapshots).
-3. It picks a **mode**: `single` (one general pass) by default, or `dual`
+4. It picks a **mode**: `single` (one general pass) by default, or `dual`
    (general + adversarial) when the PR has the `deep-review` label or a large
    diff (>800 lines).
-4. **`review.mjs`** sends the diff + PR context + project standards to OpenRouter,
+5. **`review.mjs`** sends the diff + PR context + project standards to OpenRouter,
    gets structured JSON findings, and renders a Markdown report.
-5. The workflow **upserts one PR comment** (updated in place on re-runs) and
+6. The workflow **upserts one PR comment** (updated in place on re-runs) and
    sets the **blocking** `AI Review` status: `failure` on `request_changes`
    (critical/major), `success` otherwise. Skip/bot/error paths always post
    `success` so the required check never jams (fails open on reviewer error).


### PR DESCRIPTION
## What

Turns the label gate on the reusable AI review workflow from a job-level `if` into a `gate` job that can decide with knowledge of the head commit's status.

## Why

A label that was not `deep-review` / `re-review` skipped the `review` job outright. A skipped job runs no steps, so the `if: always()` status step never fired and no `AI Review` status was ever posted for that commit. The check is required, so the PR jammed permanently: nothing to re-run, and admin merge cannot bypass a required check under `enforce_admins`.

Dependabot hit this on every PR. It labels its own PR, and the caller's concurrency group (`cancel-in-progress: true`, keyed by PR number) cancels the in-flight review for the same SHA when the label event arrives. The surviving run is the label one, which skipped. Six sifa-sdk dependabot PRs were stuck behind this today; the workaround was creating a `re-review` label and applying it by hand.

## How

- `gate` job, `if: github.event.action == 'labeled'`. `deep-review` / `re-review` pass through as before. Any other label checks `repos/{repo}/commits/{sha}/status` for an `AI Review` context: present means stop (no review spent, the check is already resolved), absent means review anyway so the check can resolve.
- `review` gains `needs: gate` and `if: !cancelled() && ... && needs.gate.outputs.stop != 'true'`. `!cancelled()` rather than `success()` because `gate` is skipped on every non-label event, and a skipped dependency must not skip the review.

Cost is unchanged on the normal path: `gate` only spins up on label events, and stops before the reviewer runs whenever a status already exists.

Alternative considered and rejected: a job that posts a neutral success whenever the review is skipped. That would clobber a real `failure` verdict on the same SHA any time someone added an unrelated label.